### PR TITLE
v1.12.5 - Patch Release

### DIFF
--- a/src/includes/class-up-project-activity.php
+++ b/src/includes/class-up-project-activity.php
@@ -444,7 +444,7 @@ class UpStream_Project_Activity {
                                     $item   = upstream_project_item_by_id( $this->ID, $item_id );
                                     $title  = isset( $item['title'] ) ? $item['title'] : $item['milestone'];
                                     $the_val = $this->format_fields( $field_id, $field_data['add'] );
-                                    $field_output .= '<span class="item">' . sprintf( __( 'New: %s - %s on %s', 'upstream' ), $field_name, $the_val, '<span class="highlight">' . $title . '</span>' ) . '</span>';
+                                    $field_output .= '<span class="item">' . sprintf( __( 'New: %s - %s on %s', 'upstream' ), $field_name, (is_array($the_val) ? json_encode($the_val) : $the_val), '<span class="highlight">' . $title . '</span>' ) . '</span>';
                                 }
 
                                 if( isset( $field_data['from'] ) ) {

--- a/src/includes/class-up-project.php
+++ b/src/includes/class-up-project.php
@@ -382,24 +382,6 @@ class UpStream_Project {
 
     }
 
-    public function remove_empty_items( $data ) {
-
-        if( isset( $data[0]['file_id'] ) && $data[0]['file_id'] == '0' )
-            unset( $data[0]['file_id'] );
-
-        // removes all NULL, FALSE and Empty Strings but leaves 0 (zero) values
-        if( isset( $data[0] ) ) {
-            $first_item = is_array( $data[0] ) ? array_filter( $data[0], 'strlen' ) : $data[0];
-            if( count( $first_item ) === 3 ) {
-                $data = null;
-            }
-        }
-
-        return $data;
-
-    }
-
-
     /*
      *
      */

--- a/src/includes/class-up-project.php
+++ b/src/includes/class-up-project.php
@@ -376,7 +376,8 @@ class UpStream_Project {
             }
         }
 
-        $data = apply_filters('upstream:project.onBeforeUpdateMissingMeta', $this->ID, $meta_key, $data);
+        $data = apply_filters('upstream:project.onBeforeUpdateMissingMeta', $data, $this->ID, $meta_key);
+
 
         $updated = update_post_meta( $this->ID, $meta_key, $data );
 

--- a/src/includes/class-up-project.php
+++ b/src/includes/class-up-project.php
@@ -376,11 +376,7 @@ class UpStream_Project {
             }
         }
 
-        // removes the last empty item. So that it can be hidden
-        // essentially deletes id, created by and created time if they are the only keys
-        if( $meta_key != '_upstream_project_milestones' ) {
-            $data = $this->remove_empty_items( $data );
-        }
+        $data = apply_filters('upstream:project.onBeforeUpdateMissingMeta', $this->ID, $meta_key, $data);
 
         $updated = update_post_meta( $this->ID, $meta_key, $data );
 

--- a/src/includes/class-up-roles.php
+++ b/src/includes/class-up-roles.php
@@ -165,7 +165,7 @@ class UpStream_Roles {
             'edit_project',
             'read_project',
             'edit_projects',
-            'edit_others_projects',
+            // 'edit_others_projects',
             // 'read_private_projects',
             // 'edit_private_projects',
             'edit_published_projects',

--- a/src/includes/up-permissions-functions.php
+++ b/src/includes/up-permissions-functions.php
@@ -198,28 +198,13 @@ function upstream_user_can_access_project($user_id, $project_id)
         }
     }
 
-    if (!$userCanAccessProject) {
+    if (!$userCanAccessProject && user_can($user, 'edit_published_projects')) {
         // Check if user is a member of the project.
         $projectMembers = upstream_project_members_ids($project_id);
         if (in_array($user->ID, $projectMembers)) {
             $userCanAccessProject = true;
-        } else {
-            // Check if the user has the "edit_published_projects" capability.
-            if (user_can($user, 'edit_published_projects')) {
-                $userCanAccessProject = true;
-            } else {
-                // Check if the user is the owner or can edit other published projects.
-                $projectOwner_id = (array)get_post_meta($project_id, '_upstream_project_owner');
-                $projectOwner_id = !empty($projectOwner_id) ? (int)$projectOwner_id[0] : 0;
-
-                if ($projectOwner_id === $user->ID || user_can($user, 'edit_others_projects')) {
-                    $userCanAccessProject = true;
-                }
-            }
         }
     }
-
-    // @todo: user_can($user, 'edit_private_projects'
 
     return $userCanAccessProject;
 }

--- a/src/languages/upstream.pot
+++ b/src/languages/upstream.pot
@@ -3,7 +3,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: UpStream v1.12.4\n"
+"Project-Id-Version: UpStream v1.12.5\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -21,28 +21,41 @@ msgstr ""
 "X-Poedit-SearchPathExcluded-0: *.js\n"
 "X-Poedit-SearchPathExcluded-1: includes/libraries\n"
 
-#: ../upstream.php:317
+#: ../upstream.php:333
 msgid "View Documentation"
 msgstr ""
 
-#: ../upstream.php:317
+#: ../upstream.php:333
 msgid "Docs"
 msgstr ""
 
-#: ../upstream.php:318
+#: ../upstream.php:334
 msgid "View Quick Start Guide"
 msgstr ""
 
-#: ../upstream.php:318
+#: ../upstream.php:334
 msgid "Quick Start Guide"
 msgstr ""
 
-#: ../upstream.php:342
+#: ../upstream.php:358
 msgid "Open Settings Page"
 msgstr ""
 
-#: ../upstream.php:343
+#: ../upstream.php:359
 msgid "Settings"
+msgstr ""
+
+#: ../upstream.php:399
+msgid "Update notice:"
+msgstr ""
+
+#: ../upstream.php:404
+msgctxt "1st %s: plugin version, 2nd %s: capability name, 3rd: UpStream User role"
+msgid "Starting from <strong>%s</strong> <code>%s</code> capability was removed from <code>%s</code> users role."
+msgstr ""
+
+#: ../upstream.php:407, ../includes/class-up-roles.php:61
+msgid "UpStream User"
 msgstr ""
 
 #: ../includes/class-up-project-activity.php:305
@@ -75,10 +88,6 @@ msgstr ""
 
 #: ../includes/class-up-roles.php:31
 msgid "UpStream Manager"
-msgstr ""
-
-#: ../includes/class-up-roles.php:61
-msgid "UpStream User"
 msgstr ""
 
 #: ../includes/class-up-roles.php:318, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:259
@@ -776,7 +785,7 @@ msgstr ""
 msgid "All %s"
 msgstr ""
 
-#: ../templates/global/sidebar.php:99, ../templates/global/sidebar.php:117, ../templates/global/sidebar.php:136, ../templates/single-project/overview.php:155, ../templates/single-project/overview.php:180, ../templates/single-project/overview.php:205
+#: ../templates/global/sidebar.php:99, ../templates/global/sidebar.php:117, ../templates/global/sidebar.php:136, ../templates/single-project/overview.php:167, ../templates/single-project/overview.php:192, ../templates/single-project/overview.php:217
 msgid "Assigned to me"
 msgstr ""
 
@@ -816,27 +825,27 @@ msgstr ""
 msgid "Currently no messages."
 msgstr ""
 
-#: ../templates/single-project/overview.php:152, ../templates/single-project/overview.php:177, ../templates/single-project/overview.php:202, ../includes/admin/metaboxes/metabox-functions.php:190, ../includes/admin/options/class-up-options-bugs.php:124, ../includes/admin/options/class-up-options-projects.php:125, ../includes/admin/options/class-up-options-tasks.php:125
+#: ../templates/single-project/overview.php:164, ../templates/single-project/overview.php:189, ../templates/single-project/overview.php:214, ../includes/admin/metaboxes/metabox-functions.php:190, ../includes/admin/options/class-up-options-bugs.php:124, ../includes/admin/options/class-up-options-projects.php:125, ../includes/admin/options/class-up-options-tasks.php:125
 msgid "Open"
 msgstr ""
 
-#: ../templates/single-project/overview.php:158, ../templates/single-project/overview.php:183, ../templates/single-project/overview.php:208
+#: ../templates/single-project/overview.php:170, ../templates/single-project/overview.php:195, ../templates/single-project/overview.php:220
 msgid "Overdue"
 msgstr ""
 
-#: ../templates/single-project/overview.php:161
+#: ../templates/single-project/overview.php:173
 msgid "Completed"
 msgstr ""
 
-#: ../templates/single-project/overview.php:164, ../templates/single-project/overview.php:189, ../templates/single-project/overview.php:214
+#: ../templates/single-project/overview.php:176, ../templates/single-project/overview.php:201, ../templates/single-project/overview.php:226
 msgid "Total"
 msgstr ""
 
-#: ../templates/single-project/overview.php:167, ../templates/single-project/overview.php:192, ../templates/single-project/overview.php:217
+#: ../templates/single-project/overview.php:179, ../templates/single-project/overview.php:204, ../templates/single-project/overview.php:229
 msgid "Overview"
 msgstr ""
 
-#: ../templates/single-project/overview.php:186, ../templates/single-project/overview.php:211, ../includes/admin/options/class-up-options-bugs.php:125, ../includes/admin/options/class-up-options-projects.php:126, ../includes/admin/options/class-up-options-tasks.php:126
+#: ../templates/single-project/overview.php:198, ../templates/single-project/overview.php:223, ../includes/admin/options/class-up-options-bugs.php:125, ../includes/admin/options/class-up-options-projects.php:126, ../includes/admin/options/class-up-options-tasks.php:126
 msgid "Closed"
 msgstr ""
 

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -149,6 +149,7 @@ Fixed:
 * Fixed Bugs table not being ordered by Due Date by default
 * Fixed some uncommon PHP errors being thrown after saving Tasks
 * Fixed UpStream Users having access to any Project
+* Fixed PHP warning being thrown on Project activity in the presence of any Reminder activity of the Email Notifications extension
 
 = [1.12.4] - 2017-10-31 =
 

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -142,6 +142,7 @@ Added:
 
 Fixed:
 * Fixed Completed/Closed Milestones, Tasks and/or Bugs counting as Overdue on frontend overview
+* Fixed Bugs table not being ordered by Due Date by default
 
 = [1.12.4] - 2017-10-31 =
 

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -139,11 +139,16 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 
 Added:
 * Added new filter "upstream:project.onBeforeUpdateMissingMeta"
+* Added method to render additional plugin update info if needed
+
+Changed:
+* UpStream Users user role no longer have "edit_others_projects" capability by default
 
 Fixed:
 * Fixed Completed/Closed Milestones, Tasks and/or Bugs counting as Overdue on frontend overview
 * Fixed Bugs table not being ordered by Due Date by default
 * Fixed some uncommon PHP errors being thrown after saving Tasks
+* Fixed UpStream Users having access to any Project
 
 = [1.12.4] - 2017-10-31 =
 

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -4,7 +4,7 @@ Tags: project, manage, management, project management, project manager, wordpres
 Requires at least: 4.5
 Tested up to: 4.8
 Requires PHP: 5.6
-Stable tag: 1.12.4
+Stable tag: 1.12.5
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -134,6 +134,10 @@ UpStream does not use the existing styling of your theme. The features and the v
 
 The format is based on [Keep a Changelog](http://keepachangelog.com)
 and this project adheres to [Semantic Versioning](http://semver.org).
+
+= [1.12.5] - @todo =
+
+@todo
 
 = [1.12.4] - 2017-10-31 =
 

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -143,6 +143,7 @@ Added:
 Fixed:
 * Fixed Completed/Closed Milestones, Tasks and/or Bugs counting as Overdue on frontend overview
 * Fixed Bugs table not being ordered by Due Date by default
+* Fixed some uncommon PHP errors being thrown after saving Tasks
 
 = [1.12.4] - 2017-10-31 =
 

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -135,7 +135,7 @@ UpStream does not use the existing styling of your theme. The features and the v
 The format is based on [Keep a Changelog](http://keepachangelog.com)
 and this project adheres to [Semantic Versioning](http://semver.org).
 
-= [1.12.5] - @todo =
+= [1.12.5] - 2017-11-09 =
 
 Added:
 * Added new filter "upstream:project.onBeforeUpdateMissingMeta"

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -140,6 +140,9 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 Added:
 * Added new filter "upstream:project.onBeforeUpdateMissingMeta"
 
+Fixed:
+* Fixed Completed/Closed Milestones, Tasks and/or Bugs counting as Overdue on frontend overview
+
 = [1.12.4] - 2017-10-31 =
 
 Added:

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -137,7 +137,8 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 
 = [1.12.5] - @todo =
 
-@todo
+Added:
+* Added new filter "upstream:project.onBeforeUpdateMissingMeta"
 
 = [1.12.4] - 2017-10-31 =
 

--- a/src/templates/single-project/bugs.php
+++ b/src/templates/single-project/bugs.php
@@ -41,7 +41,7 @@ $collapseBox = isset($pluginOptions['collapse_project_bugs']) && (bool)$pluginOp
                     </ul>
                     <div class="tab-content" style="margin-top: 7px;">
                         <div role="tabpanel" class="tab-pane active" id="bugs-table-wrapper">
-                            <table id="bugs" class="datatable table table-striped table-bordered dt-responsive nowrap" cellspacing="0" width="100%" data-order="[[ 5, &quot;asc&quot; ]]" data-type="bug">
+                            <table id="bugs" class="datatable table table-striped table-bordered dt-responsive nowrap" cellspacing="0" width="100%" data-order="[[ 4, &quot;asc&quot; ]]" data-type="bug">
                                 <thead>
                                     <?php echo upstream_output_table_header($itemType); ?>
                                 </thead>
@@ -51,7 +51,7 @@ $collapseBox = isset($pluginOptions['collapse_project_bugs']) && (bool)$pluginOp
                             </table>
                         </div>
                         <div role="tabpanel" class="tab-pane" id="my-bugs-table-wrapper">
-                            <table id="my-bugs" class="datatable table table-striped table-bordered dt-responsive nowrap" cellspacing="0" width="100%" data-order="[[ 5, &quot;asc&quot; ]]" data-type="bug">
+                            <table id="my-bugs" class="datatable table table-striped table-bordered dt-responsive nowrap" cellspacing="0" width="100%" data-order="[[ 4, &quot;asc&quot; ]]" data-type="bug">
                                 <thead>
                                     <?php echo upstream_output_table_header($itemType); ?>
                                 </thead>

--- a/src/templates/single-project/overview.php
+++ b/src/templates/single-project/overview.php
@@ -10,11 +10,11 @@ $currentTimestamp = time();
 $areMilestonesEnabled = !upstream_are_milestones_disabled() && !upstream_disable_milestones();
 if ($areMilestonesEnabled) {
     $milestonesCounts = array(
-      'open'     => 0,
-      'mine'     => 0,
-      'overdue'  => 0,
-      'finished' => 0,
-      'total'    => 0
+        'open'     => 0,
+        'mine'     => 0,
+        'overdue'  => 0,
+        'finished' => 0,
+        'total'    => 0
     );
 
     $milestones = get_post_meta($project_id, '_upstream_project_milestones');
@@ -27,21 +27,23 @@ if ($areMilestonesEnabled) {
     $milestonesCounts['total'] = count($milestones);
     if ($milestonesCounts['total'] > 0) {
         foreach ($milestones as $milestone) {
-          if (isset($milestone['assigned_to']) && (int)$milestone['assigned_to'] === $user_id) {
-            $milestonesCounts['mine']++;
-          }
-
-          if (isset($milestone['end_date']) && (int)$milestone['end_date'] > 0 && (int)$milestone['end_date'] < $currentTimestamp) {
-            $milestonesCounts['overdue']++;
-          }
-
-          if (isset($milestone['progress'])) {
-            if ((float)$milestone['progress'] < 100) {
-              $milestonesCounts['open']++;
-            } else {
-              $milestonesCounts['finished']++;
+            if (isset($milestone['assigned_to']) && (int)$milestone['assigned_to'] === $user_id) {
+                $milestonesCounts['mine']++;
             }
-          }
+
+            $progress = isset($milestone['progress']) ? (float)$milestone['progress'] : 0;
+            if ($progress < 100) {
+                $milestonesCounts['open']++;
+
+                if (isset($milestone['end_date'])
+                    && (int)$milestone['end_date'] > 0
+                    && (int)$milestone['end_date'] < $currentTimestamp
+                ) {
+                    $milestonesCounts['overdue']++;
+                }
+            } else {
+                $milestonesCounts['finished']++;
+            }
         }
     }
 }
@@ -49,17 +51,17 @@ if ($areMilestonesEnabled) {
 $areTasksEnabled = !upstream_are_tasks_disabled() && !upstream_disable_tasks();
 if ($areTasksEnabled) {
     $tasksCounts = array(
-      'open'    => 0,
-      'mine'    => 0,
-      'overdue' => 0,
-      'closed'  => 0,
-      'total'   => 0
+        'open'    => 0,
+        'mine'    => 0,
+        'overdue' => 0,
+        'closed'  => 0,
+        'total'   => 0
     );
 
     $tasksOptions = get_option('upstream_tasks');
     $tasksMap = array();
     foreach ($tasksOptions['statuses'] as $task) {
-      $tasksMap[$task['name']] = $task['type'];
+        $tasksMap[$task['name']] = $task['type'];
     }
     unset($tasksOptions);
 
@@ -72,42 +74,49 @@ if ($areTasksEnabled) {
 
     $tasksCounts['total'] = count($tasks);
     if ($tasksCounts['total'] > 0) {
-      foreach ($tasks as $task) {
-        if (isset($task['assigned_to']) && (int)$task['assigned_to'] === $user_id) {
-          $tasksCounts['mine']++;
-        }
+        foreach ($tasks as $task) {
+            if (isset($task['assigned_to']) && (int)$task['assigned_to'] === $user_id) {
+                $tasksCounts['mine']++;
+            }
 
-        if (isset($task['end_date']) && (int)$task['end_date'] > 0 && (int)$task['end_date'] < $currentTimestamp) {
-          $tasksCounts['overdue']++;
-        }
+            $progress = isset($task['progress']) ? (float)$task['progress'] : 0;
+            if ($progress < 100) {
+                if (isset($task['status'])
+                    && isset($tasksMap[$task['status']])
+                    && $tasksMap[$task['status']] === "closed"
+                ) {
+                    $tasksCounts['closed']++;
+                } else {
+                    $tasksCounts['open']++;
 
-        if (isset($task['status'])) {
-          if (!empty($task['status']) && $tasksMap[$task['status']] === 'closed') {
-            $tasksCounts['closed']++;
-          } else {
-            $tasksCounts['open']++;
-          }
-        } else {
-          $tasksCounts['open']++;
+                    if (isset($task['end_date'])
+                        && (int)$task['end_date'] > 0
+                        && (int)$task['end_date'] < $currentTimestamp
+                    ) {
+                        $tasksCounts['overdue']++;
+                    }
+                }
+            } else {
+                $tasksCounts['closed']++;
+            }
         }
-      }
     }
 }
 
 $areBugsEnabled = !upstream_disable_bugs() && !upstream_are_bugs_disabled();
 if ($areBugsEnabled) {
     $bugsCounts = array(
-      'open'    => 0,
-      'mine'    => 0,
-      'overdue' => 0,
-      'closed'  => 0,
-      'total'   => 0
+        'open'    => 0,
+        'mine'    => 0,
+        'overdue' => 0,
+        'closed'  => 0,
+        'total'   => 0
     );
 
     $bugsOptions = get_option('upstream_tasks');
     $bugsMap = array();
     foreach ($bugsOptions['statuses'] as $bug) {
-      $bugsMap[$bug['name']] = $bug['type'];
+        $bugsMap[$bug['name']] = $bug['type'];
     }
     unset($bugsOptions);
 
@@ -121,23 +130,26 @@ if ($areBugsEnabled) {
     $bugsCounts['total'] = count($bugs);
     if ($bugsCounts['total'] > 0) {
         foreach ($bugs as $bug) {
-          if (isset($bug['assigned_to']) && (int)$bug['assigned_to'] === $user_id) {
-            $bugsCounts['mine']++;
-          }
-
-          if (isset($bug['due_date']) && (int)$bug['due_date'] > 0 && (int)$bug['due_date'] < $currentTimestamp) {
-            $bugsCounts['overdue']++;
-          }
-
-          if (isset($bug['status'])) {
-            if (!empty($bug['status']) && $bugsMap[$bug['status']] === 'closed') {
-              $bugsCounts['closed']++;
-            } else {
-              $bugsCounts['open']++;
+            if (isset($bug['assigned_to']) && (int)$bug['assigned_to'] === $user_id) {
+                $bugsCounts['mine']++;
             }
-          } else {
-            $bugsCounts['open']++;
-          }
+
+            if (isset($bug['status'])
+                && !empty($bug['status'])
+                && isset($bugsMap[$bug['status']])
+                && $bugsMap[$bug['status']] === "closed"
+            ) {
+                $bugsCounts['closed']++;
+            } else {
+                $bugsCounts['open']++;
+
+                if (isset($bug['due_date'])
+                    && (int)$bug['due_date'] > 0
+                    && (int)$bug['due_date'] < $currentTimestamp
+                ) {
+                    $bugsCounts['overdue']++;
+                }
+            }
         }
     }
 }

--- a/src/upstream.php
+++ b/src/upstream.php
@@ -4,7 +4,7 @@
  * Description: A WordPress Project Management plugin by UpStream.
  * Author: UpStream
  * Author URI: https://upstreamplugin.com
- * Version: 1.12.5-beta-1.0
+ * Version: 1.12.5-beta-2.0
  * Text Domain: upstream
  * Domain Path: /languages
  */
@@ -184,7 +184,7 @@ final class UpStream
         $this->define( 'UPSTREAM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
         $this->define( 'UPSTREAM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
         $this->define( 'UPSTREAM_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
-        $this->define( 'UPSTREAM_VERSION', '1.12.5-beta-1.0' ); // @todo: update version
+        $this->define( 'UPSTREAM_VERSION', '1.12.5-beta-2.0' ); // @todo: update version
     }
 
     /**
@@ -287,7 +287,7 @@ final class UpStream
             add_action('admin_bar_menu', array($this, 'limitClientUsersToolbarItems'), 999);
         }
 
-        // Starting from v@todo:version UpStream Users role won't have 'edit_others_projects' capability by default.
+        // Starting from v1.12.5 UpStream Users role won't have 'edit_others_projects' capability by default.
         $editOtherProjectsPermissionWereRemoved = (bool)get_option('upstream:role_upstream_users:drop_edit_others_projects');
         if (!$editOtherProjectsPermissionWereRemoved) {
             $role = get_role('upstream_user');
@@ -386,7 +386,7 @@ final class UpStream
     /**
      * Render additional update info if needed.
      *
-     * @since   @todo
+     * @since   1.12.5
      * @static
      *
      * @see     https://developer.wordpress.org/reference/hooks/in_plugin_update_message-file

--- a/src/upstream.php
+++ b/src/upstream.php
@@ -99,6 +99,12 @@ final class UpStream
         add_filter('tiny_mce_before_init', 'upstream_tinymce_before_init_setup_toolbar');
         add_filter('tiny_mce_before_init', 'upstream_tinymce_before_init');
         add_filter('teeny_mce_before_init', 'upstream_tinymce_before_init_setup_toolbar');
+
+        // Render additional update info if needed.
+        global $pagenow;
+        if ($pagenow === "plugins.php") {
+            add_action('in_plugin_update_message-' . UPSTREAM_PLUGIN_BASENAME, array($this, 'renderAdditionalUpdateInfo'), 20, 2);
+        }
     }
 
     /**
@@ -281,6 +287,16 @@ final class UpStream
             add_action('admin_bar_menu', array($this, 'limitClientUsersToolbarItems'), 999);
         }
 
+        // Starting from v@todo:version UpStream Users role won't have 'edit_others_projects' capability by default.
+        $editOtherProjectsPermissionWereRemoved = (bool)get_option('upstream:role_upstream_users:drop_edit_others_projects');
+        if (!$editOtherProjectsPermissionWereRemoved) {
+            $role = get_role('upstream_user');
+            $role->remove_cap('edit_others_projects');
+            unset($role);
+
+            update_option('upstream:role_upstream_users:drop_edit_others_projects', 1);
+        }
+
         // Init action.
         do_action( 'upstream_init' );
     }
@@ -365,6 +381,32 @@ final class UpStream
         }
 
         return $isAllowed;
+    }
+
+    /**
+     * Render additional update info if needed.
+     *
+     * @since   @todo
+     * @static
+     *
+     * @see     https://developer.wordpress.org/reference/hooks/in_plugin_update_message-file
+     *
+     * @param   array   $pluginData     Plugin metadata.
+     * @param   object  $response       Metadata about the available plugin update.
+     */
+    public static function renderAdditionalUpdateInfo($pluginData, $response)
+    {
+        $updateNoticeTitleHtml = sprintf('<strong style="font-size: 1.25em; display: block; margin-top: 10px;">%s</strong>', __('Update notice:', 'upstream'));
+
+        if (version_compare(UPSTREAM_VERSION, "1.12.5", "<")) {
+            printf(
+                $updateNoticeTitleHtml .
+                _x('Starting from <strong>%s</strong> <code>%s</code> capability was removed from <code>%s</code> users role.', '1st %s: plugin version, 2nd %s: capability name, 3rd: UpStream User role', 'upstream'),
+                'v1.12.5',
+                'edit_others_projects',
+                __('UpStream User', 'upstream')
+            );
+        }
     }
 }
 endif;

--- a/src/upstream.php
+++ b/src/upstream.php
@@ -4,7 +4,7 @@
  * Description: A WordPress Project Management plugin by UpStream.
  * Author: UpStream
  * Author URI: https://upstreamplugin.com
- * Version: 1.12.5-beta-2.0
+ * Version: 1.12.5
  * Text Domain: upstream
  * Domain Path: /languages
  */
@@ -184,7 +184,7 @@ final class UpStream
         $this->define( 'UPSTREAM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
         $this->define( 'UPSTREAM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
         $this->define( 'UPSTREAM_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
-        $this->define( 'UPSTREAM_VERSION', '1.12.5-beta-2.0' ); // @todo: update version
+        $this->define( 'UPSTREAM_VERSION', '1.12.5' );
     }
 
     /**

--- a/src/upstream.php
+++ b/src/upstream.php
@@ -4,7 +4,7 @@
  * Description: A WordPress Project Management plugin by UpStream.
  * Author: UpStream
  * Author URI: https://upstreamplugin.com
- * Version: 1.12.4
+ * Version: 1.12.5-beta-1.0
  * Text Domain: upstream
  * Domain Path: /languages
  */
@@ -178,7 +178,7 @@ final class UpStream
         $this->define( 'UPSTREAM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
         $this->define( 'UPSTREAM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
         $this->define( 'UPSTREAM_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
-        $this->define( 'UPSTREAM_VERSION', '1.12.4' );
+        $this->define( 'UPSTREAM_VERSION', '1.12.5-beta-1.0' ); // @todo: update version
     }
 
     /**


### PR DESCRIPTION
**Added:**
* Added new filter `upstream:project.onBeforeUpdateMissingMeta`
* Added method to render additional plugin update info if needed

**Changed:**
* UpStream Users user role no longer have `edit_others_projects` capability by default

**Fixed:**
* Fixed Completed/Closed Milestones, Tasks and/or Bugs counting as Overdue on frontend overview - issue #197
* Fixed Bugs table not being ordered by Due Date by default - issue #209
* Fixed some uncommon PHP errors being thrown after saving Tasks - issue #210
* Fixed UpStream Users having access to any Project - issue #220
* Fixed PHP warning being thrown on Project activity in the presence of any Reminder activity of the Email Notifications extension - issue #221