### PR TITLE
cmb.shiftRows shifts comment values too. So, the comment tinyMCE text…

### DIFF
--- a/src/includes/admin/assets/js/edit-project.js
+++ b/src/includes/admin/assets/js/edit-project.js
@@ -405,7 +405,6 @@
         setTimeout(function() {
           $row.find('.up-o-tab[data-target=".up-c-tab-content-comments"]').remove();
           $row.find('.up-c-tabs-header').remove();
-          $row.find('.cmb-row[data-fieldtype="comments"]').remove();
         }, 25);
 
         $group.find( '.cmb-add-row span' ).remove();


### PR DESCRIPTION
…area should not be removed from the metabox of a new item.

<!--
  Filling out this template is required when contributing.
  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->

### Description
<!-- We must be able to understand the design of your change from this description. -->
As you can see in this YouTube video: https://youtu.be/J0v9dJDEjs0, removing the comment tinyMCE textarea from a new item metabox will complicate shifting if that new metabox item is a part of the shift move. Specifically, after a shift the metabox titles may not match the Title input field anymore and you will see an error in the console log: TypeError: inputVals[index] is undefined.

### Benefits
<!-- What benefits will be realized the code changes? -->
No inputVals[index] error on the browser console. The metabox titles would match the Title input field after a shift that involves a new metabox item.

### Possible drawbacks
<!-- What are the possible side-effects or negative impacts of the code changes? -->
This is a temporary fix. Ideally, the new metabox items shall not be able to shift to existing metabox items and vice versa.

### Applicable issues
<!-- Link any applicable Issues here -->
