### PR TITLE
CMB2 Inadvertently Destroys Comments TinyMCE During a Shift

### DIFF
--- a/src/includes/libraries/cmb2/js/cmb2-wysiwyg.js
+++ b/src/includes/libraries/cmb2/js/cmb2-wysiwyg.js
@@ -201,7 +201,7 @@ window.CMB2.wysiwyg = window.CMB2.wysiwyg || {};
 	 * @return {void}
 	 */
 	wysiwyg.shiftStart = function( evt, $btn, $from, $to ) {
-		$from.add( $to ).find( '.wp-editor-wrap textarea' ).each( function() {
+		$from.add( $to ).find( '.cmb2-wysiwyg-inner-wrap .wp-editor-wrap textarea' ).each( function() {
 			wysiwyg.destroy( $( this ).attr( 'id' ) );
 		} );
 	};


### PR DESCRIPTION
<!--
  Filling out this template is required when contributing.
  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->

### Description
<!-- We must be able to understand the design of your change from this description. -->
As you can see in this YouTube video: https://youtu.be/weP-bcVm814, CMB2 inadvertently destroys comments tinymce during a shift. Once a Comment TinyMCE has been destroyed, CMB2 does not reinit it because it was probably created by UpStream.

### Benefits
<!-- What benefits will be realized the code changes? -->
Keep the TinyMCE for Comments intact after a shift.

### Possible drawbacks
<!-- What are the possible side-effects or negative impacts of the code changes? -->
This is not a complete solution. In the video above, you can see that the existing comment: Test Comment was not shifted. Also, this fix involves a CMB2 modification. If UpStream chooses to continue modding CMB2, this mod needs to be minified into cmb.min.js.

### Applicable issues
<!-- Link any applicable Issues here -->
