### PR TITLE
Typo: $1 was missing

### DIFF
--- a/src/includes/frontend/up-table-functions.php
+++ b/src/includes/frontend/up-table-functions.php
@@ -640,7 +640,7 @@ function upstream_format_table_data( $item, $key, $setting ) {
 
     // type: textarea
     if( $setting['type'] == 'textarea' && ! empty( $field_data ) ) {
-        $field_data = preg_replace('/([^>]) *\r?\n(?! *<)/', '<br>', $field_data);
+        $field_data = preg_replace('/([^>]) *\r?\n(?! *<)/', '$1<br>', $field_data);
         $output = wp_kses_post( $field_data );
     }
 


### PR DESCRIPTION
Otherwise, the preg_replace would look like this: https://upstream.cloud77.com/wp-content/uploads/2018/02/nbsp-without-.png

Notice the &nbsps that become visible because their ;s were replaced by <br />.

<!--
  Filling out this template is required when contributing.
  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->

### Description
<!-- We must be able to understand the design of your change from this description. -->
Without the $1, the last character of the regex match would be replaced by <br>.

### Benefits
<!-- What benefits will be realized the code changes? -->
A bug fix.

### Possible drawbacks
<!-- What are the possible side-effects or negative impacts of the code changes? -->
None.

### Applicable issues
<!-- Link any applicable Issues here -->
