### PR TITLE
v1.16.1 - Patch Release

### DIFF
--- a/src/includes/admin/assets/js/edit-project.js
+++ b/src/includes/admin/assets/js/edit-project.js
@@ -1547,11 +1547,12 @@
       setTimeout(function() {
         var wrapper = $(self.parents('div.cmb-repeatable-group[data-groupid]'));
 
-        var dataWrapper = $('.up-o-tab-content', $('.postbox.cmb-row[data-iterator]', wrapper));
+        var dataWrapper = $('.up-c-tab-content-data', $('.postbox.cmb-row[data-iterator]', wrapper));
+        dataWrapper = $(dataWrapper.get(dataWrapper.length - 1));
 
         $('input[type="text"],select', dataWrapper).val('').trigger('change');
         $('.select2.select2-container', dataWrapper).remove();
-        $('select.o-select2').select2();
+        $('select.o-select2', dataWrapper).select2();
       }, 100)
     });
   });

--- a/src/includes/admin/class-up-admin-bugs-page.php
+++ b/src/includes/admin/class-up-admin-bugs-page.php
@@ -105,7 +105,7 @@ class Upstream_Bug_List extends WP_List_Table {
         <?php
         if ( ! is_singular() ) {
 
-        $projects = $this->get_projects_unique();
+        $projects = (array)$this->get_projects_unique();
         if ( ! empty( $projects ) ) { ?>
 
             <select name='project' id='project' class='postform'>
@@ -117,7 +117,7 @@ class Upstream_Bug_List extends WP_List_Table {
 
         <?php }
 
-        $users = $this->get_assigned_to_unique();
+        $users = (array)$this->get_assigned_to_unique();
         if (count($users) > 0) {
             $assigned_to = isset($_REQUEST['assigned_to']) ? (int)$_REQUEST['assigned_to'] : 0; ?>
             <select id="assigned_to" name="assigned_to" class="postform">
@@ -129,7 +129,7 @@ class Upstream_Bug_List extends WP_List_Table {
             <?php
         }
 
-        $status = $this->get_status_unique();
+        $status = (array)$this->get_status_unique();
         if ( ! empty( $status ) ) { ?>
 
             <select name='status' id='status' class='postform'>
@@ -141,7 +141,7 @@ class Upstream_Bug_List extends WP_List_Table {
 
         <?php }
 
-        $severity = $this->get_severity_unique();
+        $severity = (array)$this->get_severity_unique();
         if ( ! empty( $severity ) ) { ?>
 
             <select name='severity' id='severity' class='postform'>
@@ -454,7 +454,7 @@ class Upstream_Bug_List extends WP_List_Table {
 
     public static function sort_filter($bugs = array())
     {
-        if (count($bugs) === 0) {
+        if (!is_array($bugs) || count($bugs) === 0) {
             return array();
         }
 

--- a/src/includes/admin/class-up-admin-pointers.php
+++ b/src/includes/admin/class-up-admin-pointers.php
@@ -26,7 +26,7 @@ class UpStream_Admin_Pointers {
     public function first_project() {
         // Make sure First Steps tutorial are not shown to Client Users first time they enter a project.
         $user = wp_get_current_user();
-        if (count(array_intersect($user->roles, array('administrator', 'upstream_manager'))) === 0 &&
+        if (count(array_intersect((array)$user->roles, array('administrator', 'upstream_manager'))) === 0 &&
             !current_user_can('edit_projects')
         ) {
             return;

--- a/src/includes/admin/class-up-admin-project-columns.php
+++ b/src/includes/admin/class-up-admin-project-columns.php
@@ -75,7 +75,7 @@ class UpStream_Admin_Project_Columns {
         // Fetch current user.
         $user = wp_get_current_user();
 
-        $this->allowAllProjects = count(array_intersect($user->roles, array('administrator', 'upstream_manager'))) > 0;
+        $this->allowAllProjects = count(array_intersect((array)$user->roles, array('administrator', 'upstream_manager'))) > 0;
         if (!$this->allowAllProjects) {
             // Retrieve all projects current user can access.
             $allowedProjects = upstream_get_users_projects($user);

--- a/src/includes/admin/class-up-admin-tasks-page.php
+++ b/src/includes/admin/class-up-admin-tasks-page.php
@@ -474,7 +474,7 @@ class Upstream_Task_List extends WP_List_Table {
     }
 
     public static function sort_filter( $tasks = array() ) {
-        if (count($tasks) === 0) {
+        if (!is_array($tasks) || count($tasks) === 0) {
             return array();
         }
 

--- a/src/includes/admin/class-up-admin.php
+++ b/src/includes/admin/class-up-admin.php
@@ -45,7 +45,7 @@ class UpStream_Admin {
         }
 
         $user = wp_get_current_user();
-        $userIsUpStreamUser = count(array_intersect($user->roles, array('administrator', 'upstream_manager'))) === 0;
+        $userIsUpStreamUser = count(array_intersect((array)$user->roles, array('administrator', 'upstream_manager'))) === 0;
 
         if ($userIsUpStreamUser) {
             global $pagenow;

--- a/src/includes/admin/metaboxes/class-up-metaboxes-clients.php
+++ b/src/includes/admin/metaboxes/class-up-metaboxes-clients.php
@@ -95,10 +95,9 @@ final class UpStream_Metaboxes_Clients
         self::renderDetailsMetabox();
         self::renderLogoMetabox();
 
-        $namespace = get_class(self::$instance);
         $metaboxesCallbacksList = array('createUsersMetabox');
         foreach ($metaboxesCallbacksList as $callbackName) {
-            add_action('add_meta_boxes', array($namespace, $callbackName));
+            add_action('add_meta_boxes', array(__CLASS__, $callbackName));
         }
     }
 
@@ -204,7 +203,7 @@ final class UpStream_Metaboxes_Clients
     public static function renderUsersMetabox()
     {
         $client_id = get_the_id();
-        $usersList = self::getUsersFromClient($client_id);
+        $usersList = (array)self::getUsersFromClient($client_id);
         ?>
 
         <div class="upstream-row">
@@ -279,7 +278,7 @@ final class UpStream_Metaboxes_Clients
         add_meta_box(
             self::$prefix . 'users',
             '<span class="dashicons dashicons-groups"></span>' . __("Users", 'upstream'),
-            array(get_class(self::$instance), 'renderUsersMetabox'),
+            array(__CLASS__, 'renderUsersMetabox'),
             self::$postType,
             'normal'
         );
@@ -526,7 +525,7 @@ final class UpStream_Metaboxes_Clients
                 throw new \Exception(__('Invalid Client ID.', 'upstream'));
             }
 
-            $clientUsers = self::getUsersFromClient($clientId);
+            $clientUsers = (array)self::getUsersFromClient($clientId);
             $excludeTheseIds = array(get_current_user_id());
             if (count($clientUsers) > 0) {
                 foreach ($clientUsers as $clientUser) {
@@ -840,9 +839,8 @@ final class UpStream_Metaboxes_Clients
             'update_user_permissions' => 'updateUserPermissions'
         );
 
-        $namespace = get_class(self::$instance);
         foreach ($ajaxEndpointsSchema as $endpoint => $callbackName) {
-            add_action('wp_ajax_upstream:client.' . $endpoint, array($namespace, $callbackName));
+            add_action('wp_ajax_upstream:client.' . $endpoint, array(__CLASS__, $callbackName));
         }
     }
 }

--- a/src/includes/admin/metaboxes/class-up-metaboxes-projects.php
+++ b/src/includes/admin/metaboxes/class-up-metaboxes-projects.php
@@ -1861,7 +1861,7 @@ class UpStream_Metaboxes_Projects {
                             continue;
                         }
 
-                        $comments = get_comments(array(
+                        $comments = (array)get_comments(array(
                             'post_id'    => $project_id,
                             'status'     => $commentsStatuses,
                             'meta_query' => array(

--- a/src/includes/admin/metaboxes/class-up-metaboxes-projects.php
+++ b/src/includes/admin/metaboxes/class-up-metaboxes-projects.php
@@ -676,67 +676,6 @@ class UpStream_Metaboxes_Projects {
         return $html;
     }
 
-    /**
-     * Return the Status filter HTML.
-     *
-     * @since       1.0.0
-     * @access      private
-     * @deprecated  1.15.0
-     */
-    private function getStatusFilterHtml()
-    {
-        _doing_it_wrong(__FUNCTION__, 'Deprecated function.', '1.15.0');
-    }
-
-    /**
-     * Return the Severity filter HTML.
-     *
-     * @since       1.0.0
-     * @access      private
-     * @deprecated  1.15.0
-     */
-    private function getSeverityFilterHtml()
-    {
-        _doing_it_wrong(__FUNCTION__, 'Deprecated function.', '1.15.0');
-    }
-
-    /**
-     * Return the HTML that opens the Filters wrapper.
-     *
-     * @since       1.0.0
-     * @access      private
-     * @deprecated  1.15.0
-     */
-    private function getFiltersHeaderHtml()
-    {
-        _doing_it_wrong(__FUNCTION__, 'Deprecated function.', '1.15.0');
-    }
-
-    /**
-     * Return the HTML that closes the Filters wrapper.
-     *
-     * @since       1.0.0
-     * @access      private
-     * @deprecated  1.15.0
-     */
-    private function getFiltersFooterHtml()
-    {
-        _doing_it_wrong(__FUNCTION__, 'Deprecated function.', '1.15.0');
-    }
-
-    /**
-     * Return the Milestone filter HTML.
-     *
-     * @since       1.0.0
-     * @access      private
-     * @deprecated  1.15.0
-     */
-    private function getMilestoneFilterHtml()
-    {
-        _doing_it_wrong(__FUNCTION__, 'Deprecated function.', '1.15.0');
-    }
-
-
 /* ======================================================================================
                                         TASKS
    ====================================================================================== */

--- a/src/includes/admin/options/class-up-options-general.php
+++ b/src/includes/admin/options/class-up-options-general.php
@@ -285,10 +285,10 @@ class UpStream_Options_General {
                     )
                 ),
                 array(
-                    'name'    => __( 'Disable Project Overview', 'upstream' ),
+                    'name'    => __( 'Project Progress Icons', 'upstream' ),
                     'id'      => 'disable_project_overview',
                     'type'    => 'radio_inline',
-                    'desc'    => __( 'Choose whether to display the Project Overview section on frontend.', 'upstream' ),
+                    'desc'    => __( 'Choose whether to display the Project Progress Icons section on frontend.', 'upstream' ),
                     'default' => '0',
                     'options' => array(
                         0 => __('No', 'upstream'),

--- a/src/includes/class-up-comments.php
+++ b/src/includes/class-up-comments.php
@@ -34,7 +34,11 @@ class Comments
      */
     public function __construct()
     {
-        self::$namespace = get_class(self::$instance);
+        self::$namespace = get_class(
+            empty(self::$instance)
+            ? $this
+            : self::$instance
+        );
 
         $this->attachHooks();
     }

--- a/src/includes/frontend/class-up-view.php
+++ b/src/includes/frontend/class-up-view.php
@@ -18,7 +18,11 @@ class UpStream_View
 
     public function __construct()
     {
-        self::$namespace = get_class(self::$instance);
+        self::$namespace = get_class(
+            empty(self::$instance)
+            ? $this
+            : self::$instance
+        );
     }
 
     public static function setProject($id = 0)

--- a/src/includes/up-general-functions.php
+++ b/src/includes/up-general-functions.php
@@ -429,7 +429,7 @@ function upstream_get_users_projects($user)
 
     $data = array();
 
-    $rowset = get_posts(array(
+    $rowset = (array)get_posts(array(
         'post_type'      => "project",
         'post_status'    => "publish",
         'posts_per_page' => -1

--- a/src/includes/up-permissions-functions.php
+++ b/src/includes/up-permissions-functions.php
@@ -181,7 +181,7 @@ function upstream_user_can_access_project($user_id, $project_id)
         return false;
     }
 
-    $userIsAdmin = count(array_intersect($user->roles, array('administrator', 'upstream_manager'))) > 0;
+    $userIsAdmin = count(array_intersect((array)$user->roles, array('administrator', 'upstream_manager'))) > 0;
     if ($userIsAdmin) {
         return true;
     }

--- a/src/languages/upstream.pot
+++ b/src/languages/upstream.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the UpStream package.
 msgid ""
 msgstr ""
-"Project-Id-Version: UpStream v1.16.0\n"
+"Project-Id-Version: UpStream v1.16.1\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -58,61 +58,61 @@ msgctxt "Comment was very recently added."
 msgid "just now"
 msgstr ""
 
-#: ../includes/class-up-comment.php:342, ../includes/class-up-comment.php:352, ../includes/class-up-comments.php:402
+#: ../includes/class-up-comment.php:342, ../includes/class-up-comment.php:352, ../includes/class-up-comments.php:406
 msgid "Unable to save the data into database."
 msgstr ""
 
-#: ../includes/class-up-comment.php:448, ../includes/class-up-comments.php:675, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1897, ../includes/admin/metaboxes/metabox-functions.php:529
+#: ../includes/class-up-comment.php:448, ../includes/class-up-comments.php:679, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1836, ../includes/admin/metaboxes/metabox-functions.php:529
 msgctxt "%s = human-readable time difference"
 msgid "%s ago"
 msgstr ""
 
-#: ../includes/class-up-comments.php:105, ../includes/class-up-comments.php:205, ../includes/class-up-comments.php:214, ../includes/class-up-comments.php:300, ../includes/class-up-comments.php:376, ../includes/class-up-comments.php:561, ../includes/class-up-comments.php:577, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:460, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:521, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:588, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:722, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:772, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1807, ../includes/admin/options/class-up-options-extensions.php:318, ../includes/admin/options/class-up-options-extensions.php:418
+#: ../includes/class-up-comments.php:109, ../includes/class-up-comments.php:209, ../includes/class-up-comments.php:218, ../includes/class-up-comments.php:304, ../includes/class-up-comments.php:380, ../includes/class-up-comments.php:565, ../includes/class-up-comments.php:581, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:459, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:520, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:587, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:721, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:771, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1746, ../includes/admin/options/class-up-options-extensions.php:318, ../includes/admin/options/class-up-options-extensions.php:418
 msgid "Invalid request."
 msgstr ""
 
-#: ../includes/class-up-comments.php:115
+#: ../includes/class-up-comments.php:119
 msgid "Invalid item."
 msgstr ""
 
-#: ../includes/class-up-comments.php:127, ../includes/class-up-comments.php:589
+#: ../includes/class-up-comments.php:131, ../includes/class-up-comments.php:593
 msgid "Invalid nonce."
 msgstr ""
 
-#: ../includes/class-up-comments.php:132, ../includes/class-up-comments.php:220, ../includes/class-up-comments.php:333, ../includes/class-up-comments.php:381, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:456, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:517, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:584, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:718, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:768, ../includes/admin/options/class-up-options-extensions.php:314, ../includes/admin/options/class-up-options-extensions.php:322, ../includes/admin/options/class-up-options-extensions.php:414, ../includes/admin/options/class-up-options-extensions.php:422
+#: ../includes/class-up-comments.php:136, ../includes/class-up-comments.php:224, ../includes/class-up-comments.php:337, ../includes/class-up-comments.php:385, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:455, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:516, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:583, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:717, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:767, ../includes/admin/options/class-up-options-extensions.php:314, ../includes/admin/options/class-up-options-extensions.php:322, ../includes/admin/options/class-up-options-extensions.php:414, ../includes/admin/options/class-up-options-extensions.php:422
 msgid "You're not allowed to do this."
 msgstr ""
 
-#: ../includes/class-up-comments.php:138, ../includes/class-up-comments.php:226, ../includes/class-up-comments.php:306, ../includes/class-up-comments.php:567, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1813
+#: ../includes/class-up-comments.php:142, ../includes/class-up-comments.php:230, ../includes/class-up-comments.php:310, ../includes/class-up-comments.php:571, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1752
 msgid "Invalid Project."
 msgstr ""
 
-#: ../includes/class-up-comments.php:143, ../includes/class-up-comments.php:231, ../includes/class-up-comments.php:594
+#: ../includes/class-up-comments.php:147, ../includes/class-up-comments.php:235, ../includes/class-up-comments.php:598
 msgid "Commenting is disabled on this project."
 msgstr ""
 
-#: ../includes/class-up-comments.php:311, ../includes/class-up-comments.php:392
+#: ../includes/class-up-comments.php:315, ../includes/class-up-comments.php:396
 msgid "Comments are disabled for this project."
 msgstr ""
 
-#: ../includes/class-up-comments.php:324
+#: ../includes/class-up-comments.php:328
 msgctxt "Removing a comment in projects"
 msgid "Comment not found."
 msgstr ""
 
-#: ../includes/class-up-comments.php:338
+#: ../includes/class-up-comments.php:342
 msgid "It wasn't possible to delete this comment."
 msgstr ""
 
-#: ../includes/class-up-comments.php:387
+#: ../includes/class-up-comments.php:391
 msgid "Invalid \"%s\" parameter."
 msgstr ""
 
-#: ../includes/class-up-comments.php:397
+#: ../includes/class-up-comments.php:401
 msgid "Comment not found."
 msgstr ""
 
-#: ../includes/class-up-comments.php:933
+#: ../includes/class-up-comments.php:937
 msgctxt "Comment notification subject"
 msgid "New comment on %s"
 msgstr ""
@@ -149,7 +149,7 @@ msgstr ""
 msgid "UpStream Manager"
 msgstr ""
 
-#: ../includes/class-up-roles.php:318, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:172
+#: ../includes/class-up-roles.php:318, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:171
 msgid "UpStream Client User"
 msgstr ""
 
@@ -494,7 +494,7 @@ msgstr ""
 msgid "Tags"
 msgstr ""
 
-#: ../templates/archive-project.php:26, ../includes/frontend/up-table-functions.php:97, ../includes/frontend/up-table-functions.php:240, ../includes/frontend/up-table-functions.php:359, ../templates/single-project/bugs.php:34, ../templates/single-project/files.php:36, ../templates/single-project/tasks.php:57, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:500, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:583, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:654, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:837, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1156, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1534, ../includes/admin/options/class-up-options-milestones.php:106
+#: ../templates/archive-project.php:26, ../includes/frontend/up-table-functions.php:97, ../includes/frontend/up-table-functions.php:240, ../includes/frontend/up-table-functions.php:359, ../templates/single-project/bugs.php:34, ../templates/single-project/files.php:36, ../templates/single-project/tasks.php:57, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:500, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:583, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:654, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:776, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1095, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1473, ../includes/admin/options/class-up-options-milestones.php:106
 msgid "Title"
 msgstr ""
 
@@ -502,7 +502,7 @@ msgstr ""
 msgid "Ends at"
 msgstr ""
 
-#: ../templates/archive-project.php:30, ../includes/admin/class-up-admin-bugs-page.php:39, ../includes/admin/class-up-admin-tasks-page.php:40, ../includes/frontend/up-table-functions.php:106, ../includes/frontend/up-table-functions.php:285, ../templates/single-project/bugs.php:181, ../templates/single-project/bugs.php:184, ../templates/single-project/tasks.php:193, ../templates/single-project/tasks.php:196, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:518, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:613, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:860, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1192, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1335
+#: ../templates/archive-project.php:30, ../includes/admin/class-up-admin-bugs-page.php:39, ../includes/admin/class-up-admin-tasks-page.php:40, ../includes/frontend/up-table-functions.php:106, ../includes/frontend/up-table-functions.php:285, ../templates/single-project/bugs.php:181, ../templates/single-project/bugs.php:184, ../templates/single-project/tasks.php:193, ../templates/single-project/tasks.php:196, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:518, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:613, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:799, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1131, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1274
 msgid "Status"
 msgstr ""
 
@@ -510,7 +510,7 @@ msgstr ""
 msgid "Statuses"
 msgstr ""
 
-#: ../templates/archive-project.php:32, ../includes/frontend/up-table-functions.php:748, ../templates/single-project/bugs.php:167, ../templates/single-project/bugs.php:183, ../templates/single-project/tasks.php:195, ../templates/single-project/tasks.php:213, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:521, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:536, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:604, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:616, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1979
+#: ../templates/archive-project.php:32, ../includes/frontend/up-table-functions.php:748, ../templates/single-project/bugs.php:167, ../templates/single-project/bugs.php:183, ../templates/single-project/tasks.php:195, ../templates/single-project/tasks.php:213, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:521, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:536, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:604, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:616, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1918
 msgid "None"
 msgstr ""
 
@@ -534,7 +534,7 @@ msgstr ""
 msgid "CSV"
 msgstr ""
 
-#: ../templates/archive-project.php:245, ../includes/admin/class-up-admin-pointers.php:139, ../templates/single-project/details.php:67, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1374
+#: ../templates/archive-project.php:245, ../includes/admin/class-up-admin-pointers.php:139, ../templates/single-project/details.php:67, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1313
 msgid "%s Users"
 msgstr ""
 
@@ -542,7 +542,7 @@ msgstr ""
 msgid "%s Members"
 msgstr ""
 
-#: ../templates/archive-project.php:252, ../includes/admin/class-up-admin-project-columns.php:130, ../includes/admin/class-up-admin-tasks-page.php:35, ../includes/frontend/up-table-functions.php:48, ../includes/frontend/up-table-functions.php:142, ../templates/single-project/details.php:55, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:874
+#: ../templates/archive-project.php:252, ../includes/admin/class-up-admin-project-columns.php:130, ../includes/admin/class-up-admin-tasks-page.php:35, ../includes/frontend/up-table-functions.php:48, ../includes/frontend/up-table-functions.php:142, ../templates/single-project/details.php:55, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:813
 msgid "Progress"
 msgstr ""
 
@@ -562,15 +562,15 @@ msgstr ""
 msgid "Sign In"
 msgstr ""
 
-#: ../includes/admin/class-up-admin-bugs-page.php:37, ../includes/admin/class-up-admin-tasks-page.php:38, ../includes/admin/up-enqueues.php:60, ../includes/frontend/up-table-functions.php:26, ../includes/frontend/up-table-functions.php:102, ../includes/frontend/up-table-functions.php:245, ../includes/frontend/up-table-functions.php:376, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:294, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:849, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1167, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1545
+#: ../includes/admin/class-up-admin-bugs-page.php:37, ../includes/admin/class-up-admin-tasks-page.php:38, ../includes/admin/up-enqueues.php:60, ../includes/frontend/up-table-functions.php:26, ../includes/frontend/up-table-functions.php:102, ../includes/frontend/up-table-functions.php:245, ../includes/frontend/up-table-functions.php:376, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:294, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:788, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1106, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1484
 msgid "Assigned To"
 msgstr ""
 
-#: ../includes/admin/class-up-admin-bugs-page.php:38, ../includes/frontend/up-table-functions.php:322, ../templates/single-project/bugs.php:42, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:625, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1231
+#: ../includes/admin/class-up-admin-bugs-page.php:38, ../includes/frontend/up-table-functions.php:322, ../templates/single-project/bugs.php:42, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:625, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1170
 msgid "Due Date"
 msgstr ""
 
-#: ../includes/admin/class-up-admin-bugs-page.php:40, ../includes/frontend/up-table-functions.php:249, ../templates/single-project/bugs.php:165, ../templates/single-project/bugs.php:168, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1205, ../includes/admin/options/class-up-options-bugs.php:131
+#: ../includes/admin/class-up-admin-bugs-page.php:40, ../includes/frontend/up-table-functions.php:249, ../templates/single-project/bugs.php:165, ../templates/single-project/bugs.php:168, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1144, ../includes/admin/options/class-up-options-bugs.php:131
 msgid "Severity"
 msgstr ""
 
@@ -598,7 +598,7 @@ msgstr ""
 msgid "No %s avaliable."
 msgstr ""
 
-#: ../includes/admin/class-up-admin-client-columns.php:56, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:423
+#: ../includes/admin/class-up-admin-client-columns.php:56, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:422
 msgid "Logo"
 msgstr ""
 
@@ -606,7 +606,7 @@ msgstr ""
 msgid "Website"
 msgstr ""
 
-#: ../includes/admin/class-up-admin-client-columns.php:58, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:317
+#: ../includes/admin/class-up-admin-client-columns.php:58, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:316
 msgid "Phone"
 msgstr ""
 
@@ -614,7 +614,7 @@ msgstr ""
 msgid "Address"
 msgstr ""
 
-#: ../includes/admin/class-up-admin-client-columns.php:60, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:281
+#: ../includes/admin/class-up-admin-client-columns.php:60, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:280
 msgid "Users"
 msgstr ""
 
@@ -737,7 +737,7 @@ msgstr ""
 msgid "If there are no %s in the dropdown, add them by editing the <strong>UpStream Settings</strong>."
 msgstr ""
 
-#: ../includes/admin/class-up-admin-project-columns.php:114, ../templates/single-project/details.php:60, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1347
+#: ../includes/admin/class-up-admin-project-columns.php:114, ../templates/single-project/details.php:60, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1286
 msgid "Owner"
 msgstr ""
 
@@ -749,7 +749,7 @@ msgstr ""
 msgid "End"
 msgstr ""
 
-#: ../includes/admin/class-up-admin-tasks-page.php:39, ../includes/frontend/up-table-functions.php:59, ../includes/frontend/up-table-functions.php:194, ../templates/single-project/details.php:15, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:317, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:454, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:550, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:895, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1397
+#: ../includes/admin/class-up-admin-tasks-page.php:39, ../includes/frontend/up-table-functions.php:59, ../includes/frontend/up-table-functions.php:194, ../templates/single-project/details.php:15, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:317, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:454, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:550, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:834, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1336
 msgid "End Date"
 msgstr ""
 
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Add %d Users"
 msgstr ""
 
-#: ../includes/admin/up-enqueues.php:71, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:187
+#: ../includes/admin/up-enqueues.php:71, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:186
 msgid "No users found."
 msgstr ""
 
@@ -884,11 +884,11 @@ msgctxt "Total number of Tasks"
 msgid "Total"
 msgstr ""
 
-#: ../includes/frontend/up-table-functions.php:54, ../includes/frontend/up-table-functions.php:189, ../templates/single-project/details.php:13, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:306, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:450, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:546, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:887, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1386
+#: ../includes/frontend/up-table-functions.php:54, ../includes/frontend/up-table-functions.php:189, ../templates/single-project/details.php:13, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:306, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:450, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:546, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:826, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1325
 msgid "Start Date"
 msgstr ""
 
-#: ../includes/frontend/up-table-functions.php:63, ../includes/frontend/up-table-functions.php:198, ../templates/single-project/milestones.php:26, ../templates/single-project/tasks.php:59, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:330, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:904
+#: ../includes/frontend/up-table-functions.php:63, ../includes/frontend/up-table-functions.php:198, ../templates/single-project/milestones.php:26, ../templates/single-project/tasks.php:59, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:330, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:843
 msgid "Notes"
 msgstr ""
 
@@ -904,7 +904,7 @@ msgstr ""
 msgid "This Severity doesn't exist anymore."
 msgstr ""
 
-#: ../includes/frontend/up-table-functions.php:331, ../includes/frontend/up-table-functions.php:385, ../templates/single-project/bugs.php:36, ../templates/single-project/files.php:38, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1178, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1409, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1568
+#: ../includes/frontend/up-table-functions.php:331, ../includes/frontend/up-table-functions.php:385, ../templates/single-project/bugs.php:36, ../templates/single-project/files.php:38, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1117, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1348, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1507
 msgid "Description"
 msgstr ""
 
@@ -965,7 +965,7 @@ msgstr ""
 msgid "Me"
 msgstr ""
 
-#: ../templates/single-project/details.php:30, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1324
+#: ../templates/single-project/details.php:30, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1263
 msgid "%s Details"
 msgstr ""
 
@@ -1030,119 +1030,119 @@ msgstr ""
 msgid "invalid milestone"
 msgstr ""
 
-#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:172
+#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:171
 msgid "These are all the users assigned with the role <code>%s</code> and not related to this client yet."
 msgstr ""
 
-#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:181, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:222
+#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:180, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:221
 msgid "Name"
 msgstr ""
 
-#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:182, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:223, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:316
+#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:181, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:222, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:315
 msgid "Email"
 msgstr ""
 
-#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:213, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:216
+#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:212, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:215
 msgid "Add Existing Users"
 msgstr ""
 
-#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:224
+#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:223
 msgid "Assigned by"
 msgstr ""
 
-#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:225
+#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:224
 msgid "Assigned at"
 msgstr ""
 
-#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:226
+#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:225
 msgid "Remove?"
 msgstr ""
 
-#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:255
+#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:254
 msgid "There are no users assigned yet."
 msgstr ""
 
-#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:262
+#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:261
 msgid "Removing a user only means that they will no longer be associated with this client. Their WordPress account will not be deleted."
 msgstr ""
 
-#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:308
+#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:307
 msgid "The users listed below are those old <code>UpStream Client Users</code> that could not be automatically converted/migrated to <code>WordPress Users</code> by UpStream for some reason. More details on the Disclaimer metabox."
 msgstr ""
 
-#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:314
+#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:313
 msgid "First Name"
 msgstr ""
 
-#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:315
+#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:314
 msgid "Last Name"
 msgstr ""
 
-#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:318
+#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:317
 msgid "Migrate?"
 msgstr ""
 
-#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:319
+#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:318
 msgid "Discard?"
 msgstr ""
 
-#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:332
+#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:331
 msgid "This email address is already being used by another user."
 msgstr ""
 
-#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:335
+#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:334
 msgid "Email addresses cannot be empty."
 msgstr ""
 
-#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:338
+#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:337
 msgid "Invalid email address."
 msgstr ""
 
-#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:345
+#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:344
 msgid "empty"
 msgstr ""
 
-#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:353
+#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:352
 msgid "Migrating Client User"
 msgstr ""
 
-#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:385
+#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:384
 msgid "Details"
 msgstr ""
 
-#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:465, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:526, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:593, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:727, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:777
+#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:464, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:525, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:592, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:726, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:776
 msgid "Invalid Client ID."
 msgstr ""
 
-#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:470, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:732, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:782
+#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:469, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:731, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:781
 msgid "Invalid User ID."
 msgstr ""
 
-#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:597
+#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:596
 msgid "Users IDs cannot be empty."
 msgstr ""
 
-#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:672
+#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:671
 msgid "UpStream's Custom Permissions"
 msgstr ""
 
-#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:679
+#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:678
 msgid "Permission"
 msgstr ""
 
-#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:690, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:692
+#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:689, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:691
 msgid "Update Permissions"
 msgstr ""
 
-#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:691
+#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:690
 msgid "Updating..."
 msgstr ""
 
-#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:736, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:786
+#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:735, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:785
 msgid "This Client User is not associated with this Client."
 msgstr ""
 
-#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:791
+#: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:790
 msgid "This user doesn't seem to be a valid Client User."
 msgstr ""
 
@@ -1150,7 +1150,7 @@ msgstr ""
 msgid " Overview"
 msgstr ""
 
-#: ../includes/admin/metaboxes/class-up-metaboxes-projects.php:255, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:813, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1132, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1514
+#: ../includes/admin/metaboxes/class-up-metaboxes-projects.php:255, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:752, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1071, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1453
 msgid "Data"
 msgstr ""
 
@@ -1158,15 +1158,15 @@ msgstr ""
 msgid "Severities"
 msgstr ""
 
-#: ../includes/admin/metaboxes/class-up-metaboxes-projects.php:921
+#: ../includes/admin/metaboxes/class-up-metaboxes-projects.php:860
 msgid "Selecting a milestone will count this task's progress toward that milestone as well as overall project progress."
 msgstr ""
 
-#: ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1219
+#: ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1158
 msgid "Attachments"
 msgstr ""
 
-#: ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1662
+#: ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1601
 msgid "Activity"
 msgstr ""
 
@@ -1555,11 +1555,11 @@ msgid "Choose whether Projects can be sorted into categories by managers and use
 msgstr ""
 
 #: ../includes/admin/options/class-up-options-general.php:288
-msgid "Disable Project Overview"
+msgid "Project Progress Icons"
 msgstr ""
 
 #: ../includes/admin/options/class-up-options-general.php:291
-msgid "Choose whether to display the Project Overview section on frontend."
+msgid "Choose whether to display the Project Progress Icons section on frontend."
 msgstr ""
 
 #: ../includes/admin/options/class-up-options-general.php:299

--- a/src/languages/upstream.pot
+++ b/src/languages/upstream.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the UpStream package.
 msgid ""
 msgstr ""
-"Project-Id-Version: UpStream v1.15.1\n"
+"Project-Id-Version: UpStream v1.16.0\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -62,12 +62,12 @@ msgstr ""
 msgid "Unable to save the data into database."
 msgstr ""
 
-#: ../includes/class-up-comment.php:448, ../includes/class-up-comments.php:675, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1874, ../includes/admin/metaboxes/metabox-functions.php:529
+#: ../includes/class-up-comment.php:448, ../includes/class-up-comments.php:675, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1897, ../includes/admin/metaboxes/metabox-functions.php:529
 msgctxt "%s = human-readable time difference"
 msgid "%s ago"
 msgstr ""
 
-#: ../includes/class-up-comments.php:105, ../includes/class-up-comments.php:205, ../includes/class-up-comments.php:214, ../includes/class-up-comments.php:300, ../includes/class-up-comments.php:376, ../includes/class-up-comments.php:561, ../includes/class-up-comments.php:577, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:460, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:521, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:588, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:722, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:772, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1784, ../includes/admin/options/class-up-options-extensions.php:318, ../includes/admin/options/class-up-options-extensions.php:418
+#: ../includes/class-up-comments.php:105, ../includes/class-up-comments.php:205, ../includes/class-up-comments.php:214, ../includes/class-up-comments.php:300, ../includes/class-up-comments.php:376, ../includes/class-up-comments.php:561, ../includes/class-up-comments.php:577, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:460, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:521, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:588, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:722, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:772, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1807, ../includes/admin/options/class-up-options-extensions.php:318, ../includes/admin/options/class-up-options-extensions.php:418
 msgid "Invalid request."
 msgstr ""
 
@@ -83,7 +83,7 @@ msgstr ""
 msgid "You're not allowed to do this."
 msgstr ""
 
-#: ../includes/class-up-comments.php:138, ../includes/class-up-comments.php:226, ../includes/class-up-comments.php:306, ../includes/class-up-comments.php:567, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1790
+#: ../includes/class-up-comments.php:138, ../includes/class-up-comments.php:226, ../includes/class-up-comments.php:306, ../includes/class-up-comments.php:567, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1813
 msgid "Invalid Project."
 msgstr ""
 
@@ -117,31 +117,31 @@ msgctxt "Comment notification subject"
 msgid "New comment on %s"
 msgstr ""
 
-#: ../includes/class-up-project-activity.php:305, ../templates/archive-project.php:33, ../includes/admin/class-up-admin-bugs-page.php:253, ../includes/admin/class-up-admin-bugs-page.php:260, ../includes/admin/class-up-admin-bugs-page.php:265, ../includes/admin/class-up-admin-bugs-page.php:276, ../includes/admin/class-up-admin-client-columns.php:100, ../includes/admin/class-up-admin-client-columns.php:123, ../includes/admin/class-up-admin-project-columns.php:22, ../includes/admin/class-up-admin-tasks-page.php:260, ../includes/admin/class-up-admin-tasks-page.php:274, ../includes/admin/class-up-admin-tasks-page.php:281, ../includes/admin/class-up-admin-tasks-page.php:286, ../includes/frontend/up-table-functions.php:128, ../includes/frontend/up-table-functions.php:170, ../includes/frontend/up-table-functions.php:262, ../includes/frontend/up-table-functions.php:293, ../includes/frontend/up-table-functions.php:435, ../includes/frontend/up-template-functions.php:64, ../includes/frontend/up-template-functions.php:82, ../templates/single-project/bugs.php:56, ../templates/single-project/details.php:50, ../templates/single-project/details.php:61, ../templates/single-project/details.php:71, ../templates/single-project/files.php:37, ../templates/single-project/milestones.php:24, ../templates/single-project/tasks.php:80, ../includes/admin/metaboxes/metabox-functions.php:567
+#: ../includes/class-up-project-activity.php:319, ../templates/archive-project.php:33, ../includes/admin/class-up-admin-bugs-page.php:279, ../includes/admin/class-up-admin-bugs-page.php:285, ../includes/admin/class-up-admin-bugs-page.php:290, ../includes/admin/class-up-admin-bugs-page.php:301, ../includes/admin/class-up-admin-client-columns.php:100, ../includes/admin/class-up-admin-client-columns.php:123, ../includes/admin/class-up-admin-project-columns.php:22, ../includes/admin/class-up-admin-tasks-page.php:275, ../includes/admin/class-up-admin-tasks-page.php:300, ../includes/admin/class-up-admin-tasks-page.php:306, ../includes/admin/class-up-admin-tasks-page.php:311, ../includes/frontend/up-table-functions.php:133, ../includes/frontend/up-table-functions.php:180, ../includes/frontend/up-table-functions.php:277, ../includes/frontend/up-table-functions.php:313, ../includes/frontend/up-table-functions.php:460, ../includes/frontend/up-template-functions.php:64, ../includes/frontend/up-template-functions.php:82, ../templates/single-project/bugs.php:35, ../templates/single-project/details.php:50, ../templates/single-project/details.php:61, ../templates/single-project/details.php:71, ../templates/single-project/files.php:37, ../templates/single-project/milestones.php:24, ../templates/single-project/tasks.php:58, ../includes/admin/metaboxes/metabox-functions.php:567
 msgid "none"
 msgstr ""
 
-#: ../includes/class-up-project-activity.php:361
+#: ../includes/class-up-project-activity.php:375
 msgid "New: %s"
 msgstr ""
 
-#: ../includes/class-up-project-activity.php:367
+#: ../includes/class-up-project-activity.php:381
 msgid "Edit: %s to %s"
 msgstr ""
 
-#: ../includes/class-up-project-activity.php:404
+#: ../includes/class-up-project-activity.php:418
 msgid "Deleted: %s"
 msgstr ""
 
-#: ../includes/class-up-project-activity.php:426
+#: ../includes/class-up-project-activity.php:440
 msgid "New Item: %s"
 msgstr ""
 
-#: ../includes/class-up-project-activity.php:447
+#: ../includes/class-up-project-activity.php:461
 msgid "New: %s - %s on %s"
 msgstr ""
 
-#: ../includes/class-up-project-activity.php:456
+#: ../includes/class-up-project-activity.php:470
 msgid "Edit: %s from %s to %s on %s"
 msgstr ""
 
@@ -257,7 +257,7 @@ msgstr ""
 msgid "Bugs"
 msgstr ""
 
-#: ../includes/up-labels.php:39, ../includes/frontend/up-table-functions.php:307, ../includes/frontend/up-table-functions.php:356, ../templates/single-project/files.php:40
+#: ../includes/up-labels.php:39, ../includes/frontend/up-table-functions.php:327, ../includes/frontend/up-table-functions.php:381, ../templates/single-project/files.php:40
 msgid "File"
 msgstr ""
 
@@ -494,7 +494,7 @@ msgstr ""
 msgid "Tags"
 msgstr ""
 
-#: ../templates/archive-project.php:26, ../includes/frontend/up-table-functions.php:97, ../includes/frontend/up-table-functions.php:230, ../includes/frontend/up-table-functions.php:339, ../templates/single-project/bugs.php:55, ../templates/single-project/files.php:36, ../templates/single-project/tasks.php:79, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:488, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:571, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:642, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:825, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1144, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1522, ../includes/admin/options/class-up-options-milestones.php:106
+#: ../templates/archive-project.php:26, ../includes/frontend/up-table-functions.php:97, ../includes/frontend/up-table-functions.php:240, ../includes/frontend/up-table-functions.php:359, ../templates/single-project/bugs.php:34, ../templates/single-project/files.php:36, ../templates/single-project/tasks.php:57, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:500, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:583, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:654, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:837, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1156, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1534, ../includes/admin/options/class-up-options-milestones.php:106
 msgid "Title"
 msgstr ""
 
@@ -502,15 +502,15 @@ msgstr ""
 msgid "Ends at"
 msgstr ""
 
-#: ../templates/archive-project.php:30, ../includes/admin/class-up-admin-bugs-page.php:39, ../includes/admin/class-up-admin-tasks-page.php:40, ../includes/frontend/up-table-functions.php:106, ../includes/frontend/up-table-functions.php:270, ../templates/single-project/bugs.php:202, ../templates/single-project/bugs.php:205, ../templates/single-project/tasks.php:215, ../templates/single-project/tasks.php:218, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:506, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:601, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:848, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1180, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1323
+#: ../templates/archive-project.php:30, ../includes/admin/class-up-admin-bugs-page.php:39, ../includes/admin/class-up-admin-tasks-page.php:40, ../includes/frontend/up-table-functions.php:106, ../includes/frontend/up-table-functions.php:285, ../templates/single-project/bugs.php:181, ../templates/single-project/bugs.php:184, ../templates/single-project/tasks.php:193, ../templates/single-project/tasks.php:196, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:518, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:613, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:860, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1192, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1335
 msgid "Status"
 msgstr ""
 
-#: ../templates/archive-project.php:31, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:510, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:605, ../includes/admin/options/class-up-options-bugs.php:83, ../includes/admin/options/class-up-options-projects.php:84, ../includes/admin/options/class-up-options-tasks.php:84
+#: ../templates/archive-project.php:31, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:522, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:617, ../includes/admin/options/class-up-options-bugs.php:83, ../includes/admin/options/class-up-options-projects.php:84, ../includes/admin/options/class-up-options-tasks.php:84
 msgid "Statuses"
 msgstr ""
 
-#: ../templates/archive-project.php:32, ../includes/frontend/up-table-functions.php:708, ../templates/single-project/bugs.php:188, ../templates/single-project/bugs.php:204, ../templates/single-project/tasks.php:217, ../templates/single-project/tasks.php:235, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:509, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:524, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:592, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:604
+#: ../templates/archive-project.php:32, ../includes/frontend/up-table-functions.php:748, ../templates/single-project/bugs.php:167, ../templates/single-project/bugs.php:183, ../templates/single-project/tasks.php:195, ../templates/single-project/tasks.php:213, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:521, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:536, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:604, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:616, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1979
 msgid "None"
 msgstr ""
 
@@ -518,23 +518,23 @@ msgstr ""
 msgid "%s Complete"
 msgstr ""
 
-#: ../templates/archive-project.php:125, ../templates/archive-project.php:149, ../templates/single-project/bugs.php:108, ../templates/single-project/bugs.php:132, ../templates/single-project/files.php:86, ../templates/single-project/files.php:110, ../templates/single-project/milestones.php:72, ../templates/single-project/milestones.php:96, ../templates/single-project/tasks.php:137, ../templates/single-project/tasks.php:161
+#: ../templates/archive-project.php:125, ../templates/archive-project.php:149, ../templates/single-project/bugs.php:87, ../templates/single-project/bugs.php:111, ../templates/single-project/files.php:86, ../templates/single-project/files.php:110, ../templates/single-project/milestones.php:72, ../templates/single-project/milestones.php:96, ../templates/single-project/tasks.php:115, ../templates/single-project/tasks.php:139
 msgid "Toggle Filters"
 msgstr ""
 
-#: ../templates/archive-project.php:128, ../templates/archive-project.php:153, ../templates/single-project/bugs.php:111, ../templates/single-project/bugs.php:136, ../templates/single-project/files.php:89, ../templates/single-project/files.php:114, ../templates/single-project/milestones.php:75, ../templates/single-project/milestones.php:100, ../templates/single-project/tasks.php:140, ../templates/single-project/tasks.php:165
+#: ../templates/archive-project.php:128, ../templates/archive-project.php:153, ../templates/single-project/bugs.php:90, ../templates/single-project/bugs.php:115, ../templates/single-project/files.php:89, ../templates/single-project/files.php:114, ../templates/single-project/milestones.php:75, ../templates/single-project/milestones.php:100, ../templates/single-project/tasks.php:118, ../templates/single-project/tasks.php:143
 msgid "Export"
 msgstr ""
 
-#: ../templates/archive-project.php:134, ../templates/archive-project.php:159, ../templates/single-project/bugs.php:117, ../templates/single-project/bugs.php:142, ../templates/single-project/files.php:95, ../templates/single-project/files.php:120, ../templates/single-project/milestones.php:81, ../templates/single-project/milestones.php:106, ../templates/single-project/tasks.php:146, ../templates/single-project/tasks.php:171
+#: ../templates/archive-project.php:134, ../templates/archive-project.php:159, ../templates/single-project/bugs.php:96, ../templates/single-project/bugs.php:121, ../templates/single-project/files.php:95, ../templates/single-project/files.php:120, ../templates/single-project/milestones.php:81, ../templates/single-project/milestones.php:106, ../templates/single-project/tasks.php:124, ../templates/single-project/tasks.php:149
 msgid "Plain Text"
 msgstr ""
 
-#: ../templates/archive-project.php:139, ../templates/archive-project.php:164, ../includes/frontend/up-enqueues.php:95, ../templates/single-project/bugs.php:122, ../templates/single-project/bugs.php:147, ../templates/single-project/files.php:100, ../templates/single-project/files.php:125, ../templates/single-project/milestones.php:86, ../templates/single-project/milestones.php:111, ../templates/single-project/tasks.php:151, ../templates/single-project/tasks.php:176
+#: ../templates/archive-project.php:139, ../templates/archive-project.php:164, ../includes/frontend/up-enqueues.php:95, ../templates/single-project/bugs.php:101, ../templates/single-project/bugs.php:126, ../templates/single-project/files.php:100, ../templates/single-project/files.php:125, ../templates/single-project/milestones.php:86, ../templates/single-project/milestones.php:111, ../templates/single-project/tasks.php:129, ../templates/single-project/tasks.php:154
 msgid "CSV"
 msgstr ""
 
-#: ../templates/archive-project.php:245, ../includes/admin/class-up-admin-pointers.php:139, ../templates/single-project/details.php:67, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1362
+#: ../templates/archive-project.php:245, ../includes/admin/class-up-admin-pointers.php:139, ../templates/single-project/details.php:67, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1374
 msgid "%s Users"
 msgstr ""
 
@@ -542,7 +542,7 @@ msgstr ""
 msgid "%s Members"
 msgstr ""
 
-#: ../templates/archive-project.php:252, ../includes/admin/class-up-admin-project-columns.php:130, ../includes/admin/class-up-admin-tasks-page.php:35, ../includes/frontend/up-table-functions.php:48, ../includes/frontend/up-table-functions.php:137, ../templates/single-project/details.php:55, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:862
+#: ../templates/archive-project.php:252, ../includes/admin/class-up-admin-project-columns.php:130, ../includes/admin/class-up-admin-tasks-page.php:35, ../includes/frontend/up-table-functions.php:48, ../includes/frontend/up-table-functions.php:142, ../templates/single-project/details.php:55, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:874
 msgid "Progress"
 msgstr ""
 
@@ -562,15 +562,15 @@ msgstr ""
 msgid "Sign In"
 msgstr ""
 
-#: ../includes/admin/class-up-admin-bugs-page.php:37, ../includes/admin/class-up-admin-tasks-page.php:38, ../includes/frontend/up-table-functions.php:26, ../includes/frontend/up-table-functions.php:102, ../includes/frontend/up-table-functions.php:235, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:282, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:837, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1155
+#: ../includes/admin/class-up-admin-bugs-page.php:37, ../includes/admin/class-up-admin-tasks-page.php:38, ../includes/admin/up-enqueues.php:60, ../includes/frontend/up-table-functions.php:26, ../includes/frontend/up-table-functions.php:102, ../includes/frontend/up-table-functions.php:245, ../includes/frontend/up-table-functions.php:376, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:294, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:849, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1167, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1545
 msgid "Assigned To"
 msgstr ""
 
-#: ../includes/admin/class-up-admin-bugs-page.php:38, ../includes/frontend/up-table-functions.php:302, ../templates/single-project/bugs.php:63, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:613, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1219
+#: ../includes/admin/class-up-admin-bugs-page.php:38, ../includes/frontend/up-table-functions.php:322, ../templates/single-project/bugs.php:42, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:625, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1231
 msgid "Due Date"
 msgstr ""
 
-#: ../includes/admin/class-up-admin-bugs-page.php:40, ../includes/frontend/up-table-functions.php:239, ../templates/single-project/bugs.php:186, ../templates/single-project/bugs.php:189, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1193, ../includes/admin/options/class-up-options-bugs.php:131
+#: ../includes/admin/class-up-admin-bugs-page.php:40, ../includes/frontend/up-table-functions.php:249, ../templates/single-project/bugs.php:165, ../templates/single-project/bugs.php:168, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1205, ../includes/admin/options/class-up-options-bugs.php:131
 msgid "Severity"
 msgstr ""
 
@@ -590,11 +590,11 @@ msgstr ""
 msgid "Filter"
 msgstr ""
 
-#: ../includes/admin/class-up-admin-bugs-page.php:350, ../includes/admin/class-up-admin-tasks-page.php:367
+#: ../includes/admin/class-up-admin-bugs-page.php:375, ../includes/admin/class-up-admin-tasks-page.php:392
 msgid "(no title)"
 msgstr ""
 
-#: ../includes/admin/class-up-admin-bugs-page.php:538, ../includes/admin/class-up-admin-tasks-page.php:518
+#: ../includes/admin/class-up-admin-bugs-page.php:581, ../includes/admin/class-up-admin-tasks-page.php:551
 msgid "No %s avaliable."
 msgstr ""
 
@@ -737,7 +737,7 @@ msgstr ""
 msgid "If there are no %s in the dropdown, add them by editing the <strong>UpStream Settings</strong>."
 msgstr ""
 
-#: ../includes/admin/class-up-admin-project-columns.php:114, ../templates/single-project/details.php:60, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1335
+#: ../includes/admin/class-up-admin-project-columns.php:114, ../templates/single-project/details.php:60, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1347
 msgid "Owner"
 msgstr ""
 
@@ -749,11 +749,11 @@ msgstr ""
 msgid "End"
 msgstr ""
 
-#: ../includes/admin/class-up-admin-tasks-page.php:39, ../includes/frontend/up-table-functions.php:59, ../includes/frontend/up-table-functions.php:184, ../templates/single-project/details.php:15, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:305, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:442, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:538, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:883, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1385
+#: ../includes/admin/class-up-admin-tasks-page.php:39, ../includes/frontend/up-table-functions.php:59, ../includes/frontend/up-table-functions.php:194, ../templates/single-project/details.php:15, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:317, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:454, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:550, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:895, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1397
 msgid "End Date"
 msgstr ""
 
-#: ../includes/admin/class-up-admin-tasks-page.php:246, ../includes/admin/class-up-admin-tasks-page.php:256
+#: ../includes/admin/class-up-admin-tasks-page.php:261, ../includes/admin/class-up-admin-tasks-page.php:271
 msgid "Complete"
 msgstr ""
 
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Add Comment Reply"
 msgstr ""
 
-#: ../includes/admin/up-enqueues.php:50, ../includes/admin/up-enqueues.php:71
+#: ../includes/admin/up-enqueues.php:50, ../includes/admin/up-enqueues.php:72
 msgid "Adding..."
 msgstr ""
 
@@ -789,7 +789,7 @@ msgstr ""
 msgid "Approving..."
 msgstr ""
 
-#: ../includes/admin/up-enqueues.php:58, ../includes/admin/up-enqueues.php:72
+#: ../includes/admin/up-enqueues.php:58, ../includes/admin/up-enqueues.php:73
 msgid "Are you sure? This action cannot be undone."
 msgstr ""
 
@@ -797,39 +797,39 @@ msgstr ""
 msgid "This comment is not visible by regular users."
 msgstr ""
 
-#: ../includes/admin/up-enqueues.php:65
+#: ../includes/admin/up-enqueues.php:66
 msgid "UpStream requires jQuery."
 msgstr ""
 
-#: ../includes/admin/up-enqueues.php:66
+#: ../includes/admin/up-enqueues.php:67
 msgid "There's no users assigned yet."
 msgstr ""
 
-#: ../includes/admin/up-enqueues.php:67
+#: ../includes/admin/up-enqueues.php:68
 msgid "Please, select at least one user"
 msgstr ""
 
-#: ../includes/admin/up-enqueues.php:68
+#: ../includes/admin/up-enqueues.php:69
 msgid "Add 1 User"
 msgstr ""
 
-#: ../includes/admin/up-enqueues.php:69
+#: ../includes/admin/up-enqueues.php:70
 msgid "Add %d Users"
 msgstr ""
 
-#: ../includes/admin/up-enqueues.php:70, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:187
+#: ../includes/admin/up-enqueues.php:71, ../includes/admin/metaboxes/class-up-metaboxes-clients.php:187
 msgid "No users found."
 msgstr ""
 
-#: ../includes/admin/up-enqueues.php:73
+#: ../includes/admin/up-enqueues.php:74
 msgid "Fetching data..."
 msgstr ""
 
-#: ../includes/admin/up-enqueues.php:74
+#: ../includes/admin/up-enqueues.php:75
 msgid "No data found."
 msgstr ""
 
-#: ../includes/admin/up-enqueues.php:75
+#: ../includes/admin/up-enqueues.php:76
 msgid "Managing %s's Permissions"
 msgstr ""
 
@@ -884,43 +884,39 @@ msgctxt "Total number of Tasks"
 msgid "Total"
 msgstr ""
 
-#: ../includes/frontend/up-table-functions.php:54, ../includes/frontend/up-table-functions.php:179, ../templates/single-project/details.php:13, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:294, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:438, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:534, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:875, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1374
+#: ../includes/frontend/up-table-functions.php:54, ../includes/frontend/up-table-functions.php:189, ../templates/single-project/details.php:13, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:306, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:450, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:546, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:887, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1386
 msgid "Start Date"
 msgstr ""
 
-#: ../includes/frontend/up-table-functions.php:63, ../includes/frontend/up-table-functions.php:188, ../templates/single-project/milestones.php:26, ../templates/single-project/tasks.php:81, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:318, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:892
+#: ../includes/frontend/up-table-functions.php:63, ../includes/frontend/up-table-functions.php:198, ../templates/single-project/milestones.php:26, ../templates/single-project/tasks.php:59, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:330, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:904
 msgid "Notes"
 msgstr ""
 
-#: ../includes/frontend/up-table-functions.php:125, ../includes/frontend/up-table-functions.php:290
-msgid "invalid status"
+#: ../includes/frontend/up-table-functions.php:127, ../includes/frontend/up-table-functions.php:307
+msgid "This Status doesn't exist anymore."
 msgstr ""
 
-#: ../includes/frontend/up-table-functions.php:167, ../templates/single-project/tasks.php:87
-msgid "invalid milestone"
+#: ../includes/frontend/up-table-functions.php:174
+msgid "This Milestone doesn't exist anymore."
 msgstr ""
 
-#: ../includes/frontend/up-table-functions.php:259
-msgid "invalid severity"
+#: ../includes/frontend/up-table-functions.php:271
+msgid "This Severity doesn't exist anymore."
 msgstr ""
 
-#: ../includes/frontend/up-table-functions.php:311, ../includes/frontend/up-table-functions.php:360, ../templates/single-project/bugs.php:57, ../templates/single-project/files.php:38, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1166, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1397, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1545
+#: ../includes/frontend/up-table-functions.php:331, ../includes/frontend/up-table-functions.php:385, ../templates/single-project/bugs.php:36, ../templates/single-project/files.php:38, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1178, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1409, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1568
 msgid "Description"
 msgstr ""
 
-#: ../includes/frontend/up-table-functions.php:344, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:646
+#: ../includes/frontend/up-table-functions.php:364, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:658
 msgid "Uploaded by"
 msgstr ""
 
-#: ../includes/frontend/up-table-functions.php:350, ../templates/single-project/files.php:41
+#: ../includes/frontend/up-table-functions.php:370, ../templates/single-project/files.php:41
 msgid "Upload Date"
 msgstr ""
 
-#: ../includes/frontend/up-table-functions.php:446, ../templates/single-project/milestones.php:28
-msgid "invalid user"
-msgstr ""
-
-#: ../includes/frontend/up-table-functions.php:607
+#: ../includes/frontend/up-table-functions.php:647
 msgid "No results found."
 msgstr ""
 
@@ -948,28 +944,28 @@ msgstr ""
 msgid "Log Out"
 msgstr ""
 
-#: ../templates/single-project/bugs.php:58, ../templates/single-project/files.php:39, ../templates/single-project/milestones.php:27, ../templates/single-project/tasks.php:82
+#: ../templates/single-project/bugs.php:37, ../templates/single-project/files.php:39, ../templates/single-project/milestones.php:27, ../templates/single-project/tasks.php:60
 msgid "Comments"
 msgstr ""
 
-#: ../templates/single-project/bugs.php:60, ../templates/single-project/tasks.php:84, ../templates/single-project/tasks.php:93
+#: ../templates/single-project/bugs.php:39, ../templates/single-project/tasks.php:62, ../templates/single-project/tasks.php:71
 msgctxt "%s: column name. Error message when data reference is not found"
 msgid "invalid %s"
 msgstr ""
 
-#: ../templates/single-project/bugs.php:168, ../templates/single-project/milestones.php:134, ../templates/single-project/tasks.php:197, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:424, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:492, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:575
+#: ../templates/single-project/bugs.php:147, ../templates/single-project/files.php:163, ../templates/single-project/milestones.php:134, ../templates/single-project/tasks.php:175, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:436, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:504, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:587
 msgid "Assignee"
 msgstr ""
 
-#: ../templates/single-project/bugs.php:170, ../templates/single-project/milestones.php:136, ../templates/single-project/tasks.php:199, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:428, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:496, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:579, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:650
+#: ../templates/single-project/bugs.php:149, ../templates/single-project/files.php:165, ../templates/single-project/milestones.php:136, ../templates/single-project/tasks.php:177, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:440, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:508, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:591, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:662
 msgid "Nobody"
 msgstr ""
 
-#: ../templates/single-project/bugs.php:171, ../templates/single-project/files.php:148, ../templates/single-project/milestones.php:137, ../templates/single-project/tasks.php:200, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:427, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:495, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:578, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:649
+#: ../templates/single-project/bugs.php:150, ../templates/single-project/files.php:148, ../templates/single-project/files.php:166, ../templates/single-project/milestones.php:137, ../templates/single-project/tasks.php:178, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:439, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:507, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:590, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:661
 msgid "Me"
 msgstr ""
 
-#: ../templates/single-project/details.php:30, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1312
+#: ../templates/single-project/details.php:30, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1324
 msgid "%s Details"
 msgstr ""
 
@@ -989,17 +985,21 @@ msgstr ""
 msgid "Uploader"
 msgstr ""
 
-#: ../templates/single-project/milestones.php:22, ../templates/single-project/tasks.php:88
-msgid "Starting at"
+#: ../templates/single-project/milestones.php:22, ../templates/single-project/tasks.php:66
+msgid "Starting after"
 msgstr ""
 
-#: ../templates/single-project/milestones.php:23, ../templates/single-project/tasks.php:89
-msgid "Ending at"
+#: ../templates/single-project/milestones.php:23, ../templates/single-project/tasks.php:67
+msgid "Ending before"
 msgstr ""
 
 #: ../templates/single-project/milestones.php:25
 msgctxt "Task status"
 msgid "Open"
+msgstr ""
+
+#: ../templates/single-project/milestones.php:28
+msgid "invalid user"
 msgstr ""
 
 #: ../templates/single-project/overview.php:164, ../templates/single-project/overview.php:189, ../templates/single-project/overview.php:214, ../includes/admin/metaboxes/metabox-functions.php:190, ../includes/admin/options/class-up-options-bugs.php:124, ../includes/admin/options/class-up-options-projects.php:125, ../includes/admin/options/class-up-options-tasks.php:125
@@ -1024,6 +1024,10 @@ msgstr ""
 
 #: ../templates/single-project/overview.php:198, ../templates/single-project/overview.php:223, ../includes/admin/options/class-up-options-bugs.php:125, ../includes/admin/options/class-up-options-projects.php:126, ../includes/admin/options/class-up-options-tasks.php:126
 msgid "Closed"
+msgstr ""
+
+#: ../templates/single-project/tasks.php:65
+msgid "invalid milestone"
 msgstr ""
 
 #: ../includes/admin/metaboxes/class-up-metaboxes-clients.php:172
@@ -1142,27 +1146,27 @@ msgstr ""
 msgid "This user doesn't seem to be a valid Client User."
 msgstr ""
 
-#: ../includes/admin/metaboxes/class-up-metaboxes-projects.php:121
+#: ../includes/admin/metaboxes/class-up-metaboxes-projects.php:133
 msgid " Overview"
 msgstr ""
 
-#: ../includes/admin/metaboxes/class-up-metaboxes-projects.php:243, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:801, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1120, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1502
+#: ../includes/admin/metaboxes/class-up-metaboxes-projects.php:255, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:813, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1132, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1514
 msgid "Data"
 msgstr ""
 
-#: ../includes/admin/metaboxes/class-up-metaboxes-projects.php:589, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:593
+#: ../includes/admin/metaboxes/class-up-metaboxes-projects.php:601, ../includes/admin/metaboxes/class-up-metaboxes-projects.php:605
 msgid "Severities"
 msgstr ""
 
-#: ../includes/admin/metaboxes/class-up-metaboxes-projects.php:909
+#: ../includes/admin/metaboxes/class-up-metaboxes-projects.php:921
 msgid "Selecting a milestone will count this task's progress toward that milestone as well as overall project progress."
 msgstr ""
 
-#: ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1207
+#: ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1219
 msgid "Attachments"
 msgstr ""
 
-#: ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1639
+#: ../includes/admin/metaboxes/class-up-metaboxes-projects.php:1662
 msgid "Activity"
 msgstr ""
 
@@ -1186,19 +1190,19 @@ msgstr ""
 msgid "This comment and its replies are not visible by regular users."
 msgstr ""
 
-#: ../includes/admin/metaboxes/metabox-functions.php:879
+#: ../includes/admin/metaboxes/metabox-functions.php:917
 msgid "Not Assigned"
 msgstr ""
 
-#: ../includes/admin/metaboxes/metabox-functions.php:940
+#: ../includes/admin/metaboxes/metabox-functions.php:978
 msgid "No project selected"
 msgstr ""
 
-#: ../includes/admin/metaboxes/metabox-functions.php:944
+#: ../includes/admin/metaboxes/metabox-functions.php:982
 msgid "No client selected"
 msgstr ""
 
-#: ../includes/admin/metaboxes/metabox-functions.php:954
+#: ../includes/admin/metaboxes/metabox-functions.php:992
 msgid "No users found"
 msgstr ""
 

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -140,6 +140,7 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 
 Fixed:
 * Fixed avatar infinite multiplication after adding new items to a Project in wp-admin
+* Fixed recent PHP warnings thrown under PHP 7.2
 
 = [1.16.0] - 2018-03-08 =
 

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -141,6 +141,9 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 Changed:
 * Changed "Disable Project Overview" option label to "Project Progress Icons"
 
+Removed:
+* Removed deprecated methods on v1.15.0
+
 Fixed:
 * Fixed avatar infinite multiplication after adding new items to a Project in wp-admin
 * Fixed recent PHP warnings thrown under PHP 7.2

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -136,7 +136,7 @@ UpStream does not use the existing styling of your theme. The features and the v
 The format is based on [Keep a Changelog](http://keepachangelog.com)
 and this project adheres to [Semantic Versioning](http://semver.org).
 
-= [1.16.1] - @todo =
+= [1.16.1] - 2018-03-13 =
 
 Changed:
 * Changed "Disable Project Overview" option label to "Project Progress Icons"

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -4,7 +4,7 @@ Tags: project, manage, management, project management, project manager, wordpres
 Requires at least: 4.5
 Tested up to: 4.9
 Requires PHP: 5.6
-Stable tag: 1.16.0
+Stable tag: 1.16.1
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -135,6 +135,8 @@ UpStream does not use the existing styling of your theme. The features and the v
 
 The format is based on [Keep a Changelog](http://keepachangelog.com)
 and this project adheres to [Semantic Versioning](http://semver.org).
+
+= [1.16.1] - @todo =
 
 = [1.16.0] - 2018-03-08 =
 

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -138,6 +138,9 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 
 = [1.16.1] - @todo =
 
+Changed:
+* Changed "Disable Project Overview" option label to "Project Progress Icons"
+
 Fixed:
 * Fixed avatar infinite multiplication after adding new items to a Project in wp-admin
 * Fixed recent PHP warnings thrown under PHP 7.2

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -138,6 +138,9 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 
 = [1.16.1] - @todo =
 
+Fixed:
+* Fixed avatar infinite multiplication after adding new items to a Project in wp-admin
+
 = [1.16.0] - 2018-03-08 =
 
 Added:

--- a/src/templates/single-project/details.php
+++ b/src/templates/single-project/details.php
@@ -65,7 +65,7 @@ $isClientsDisabled = is_clients_disabled();
         <?php if (!$isClientsDisabled && $project->client_id > 0): ?>
         <div class="col-xs-12 col-sm-6 col-md-4 col-lg-4">
           <p class="title"><?php printf(__('%s Users', 'upstream'), upstream_client_label()); ?></p>
-          <?php if (count($project->clientUsers) > 0): ?>
+          <?php if (is_array($project->clientUsers) && count($project->clientUsers) > 0): ?>
           <?php upstream_output_client_users() ?>
           <?php else: ?>
           <span><i class="text-muted">(<?php _e('none', 'upstream'); ?>)</i></span>

--- a/src/upstream.php
+++ b/src/upstream.php
@@ -4,7 +4,7 @@
  * Description: A WordPress Project Management plugin by UpStream.
  * Author: UpStream
  * Author URI: https://upstreamplugin.com
- * Version: 1.16.0
+ * Version: 1.16.1
  * Text Domain: upstream
  * Domain Path: /languages
  */
@@ -187,7 +187,7 @@ final class UpStream
         $this->define( 'UPSTREAM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
         $this->define( 'UPSTREAM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
         $this->define( 'UPSTREAM_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
-        $this->define( 'UPSTREAM_VERSION', '1.16.0' );
+        $this->define( 'UPSTREAM_VERSION', '1.16.1' );
     }
 
     /**


### PR DESCRIPTION
### Changed:
* Changed "Disable Project Overview" option label to "Project Progress Icons" - issue #385 

### Removed:
* Removed deprecated methods on v1.15.0

### Fixed:
* Fixed avatar infinite multiplication after adding new items to a Project in wp-admin
* Fixed recent PHP warnings thrown under PHP 7.2 - issue #406 