### PR TITLE
In the backend, Assigned To fields end with [assigned_to][]

### DIFF
--- a/src/includes/admin/metaboxes/class-up-metaboxes-projects.php
+++ b/src/includes/admin/metaboxes/class-up-metaboxes-projects.php
@@ -434,7 +434,7 @@ class UpStream_Metaboxes_Projects {
           </div>
           <div class="up-c-filter">
             <label for="<?php echo $prefix . 'assignee'; ?>" class="up-s-mb-2"><?php _e('Assignee', 'upstream'); ?></label>
-            <select id="<?php echo $prefix . 'assignee'; ?>" class="up-o-filter o-select2" data-column="assigned_to" data-placeholder="" multiple>
+            <select id="<?php echo $prefix . 'assignee'; ?>" class="up-o-filter o-select2" data-column="assigned_to][" data-placeholder="" multiple>
               <option></option>
               <option value="<?php echo $currentUserId; ?>"><?php _e('Me', 'upstream'); ?></option>
               <option value="__none__"><?php _e('Nobody', 'upstream'); ?></option>
@@ -502,7 +502,7 @@ class UpStream_Metaboxes_Projects {
           </div>
           <div class="up-c-filter">
             <label for="<?php echo $prefix . 'assignee'; ?>" class="up-s-mb-2"><?php _e('Assignee', 'upstream'); ?></label>
-            <select id="<?php echo $prefix . 'assignee'; ?>" class="up-o-filter o-select2" data-column="assigned_to" multiple data-placeholder="">
+            <select id="<?php echo $prefix . 'assignee'; ?>" class="up-o-filter o-select2" data-column="assigned_to][" multiple data-placeholder="">
               <option></option>
               <option value="<?php echo $currentUserId; ?>"><?php _e('Me', 'upstream'); ?></option>
               <option value="__none__"><?php _e('Nobody', 'upstream'); ?></option>
@@ -585,7 +585,7 @@ class UpStream_Metaboxes_Projects {
           </div>
           <div class="up-c-filter">
             <label for="<?php echo $prefix . 'assignee'; ?>" class="up-s-mb-2"><?php _e('Assignee', 'upstream'); ?></label>
-            <select id="<?php echo $prefix . 'assignee'; ?>" class="up-o-filter o-select2" data-column="assigned_to" data-placeholder="" multiple>
+            <select id="<?php echo $prefix . 'assignee'; ?>" class="up-o-filter o-select2" data-column="assigned_to][" data-placeholder="" multiple>
               <option></option>
               <option value="<?php echo $currentUserId; ?>"><?php _e('Me', 'upstream'); ?></option>
               <option value="__none__"><?php _e('Nobody', 'upstream'); ?></option>


### PR DESCRIPTION
instead of the expected [assigned_to].

To work with this line in edit-project.js:

theColumn = $('[name$="['+ filter.column +']"]', tr);

The data-column needs to be changed from assigned_to to assigned_to][

<!--
  Filling out this template is required when contributing.
  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->

### Description
<!-- We must be able to understand the design of your change from this description. -->
Assignee filter field does not work on the backend.

### Benefits
<!-- What benefits will be realized the code changes? -->
This is one of the two fixes needed to repair the Assignee filter field on the backend.

### Possible drawbacks
<!-- What are the possible side-effects or negative impacts of the code changes? -->
None.

### Applicable issues
<!-- Link any applicable Issues here -->
#433 