### PR TITLE
=== is too strict

### DIFF
--- a/src/includes/admin/assets/js/edit-project.js
+++ b/src/includes/admin/assets/js/edit-project.js
@@ -1466,7 +1466,7 @@
                 if (filter.value[valueIndex] === '__none__') {
                   shouldDisplay = !columnValue || columnValue === '__none__';
                 } else {
-                  shouldDisplay = columnValue === filter.value[valueIndex];
+                  shouldDisplay = columnValue == filter.value[valueIndex];
                 }
 
                 if (shouldDisplay) {


### PR DESCRIPTION
It breaks the Assignee filter field.

<!--
  Filling out this template is required when contributing.
  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->

### Description
<!-- We must be able to understand the design of your change from this description. -->
=== will never match the Assignee filter entered with the values from Assigned To fields.

### Benefits
<!-- What benefits will be realized the code changes? -->
Fix for the Assignee filter.

### Possible drawbacks
<!-- What are the possible side-effects or negative impacts of the code changes? -->
None.

### Applicable issues
<!-- Link any applicable Issues here -->
#433 