### PR TITLE
There can be more than one users assigned to an item now.

### DIFF
--- a/src/includes/class-up-comments.php
+++ b/src/includes/class-up-comments.php
@@ -810,17 +810,21 @@ class Comments
                     $item = (object)array(
                         'id'          => $row['id'],
                         'title'       => $row[$titleKey],
-                        'assigned_to' => isset($row['assigned_to']) ? (int)$row['assigned_to'] : 0,
+                        'assigned_to' => isset($row['assigned_to']) ? (array)$row['assigned_to'] : array(),
                         'created_by'  => isset($row['created_by']) ? (int)$row['created_by'] : 0,
                         'type'        => $key
                     );
 
-                    if ($item->assigned_to > 0) {
-                        $user = $getUser($item->assigned_to);
-                        if (empty($user)) {
-                            $item->assigned_to = 0;
-                        } else {
-                            $item->assigned_to = $user->id;
+                    if( count( $item->assigned_to ) > 0 ) {
+
+                        foreach( $item->assigned_to as $key => $assignee ) {
+
+                            $user = $getUser( $assignee );
+                            if (empty($user)) {
+                                $item->assigned_to[$key] = 0;
+                            } else {
+                                $item->assigned_to[$key] = $user->id;
+                            }
                         }
                     }
 
@@ -873,9 +877,16 @@ class Comments
                 $fetchProjectMetaAsMap($project->id, $comment->target, $project->{$comment->target . 's'});
                 foreach ($project->{$comment->target . 's'} as $item) {
                     if ($item->id === $comment->target_id) {
-                        if ($item->assigned_to > 0) {
-                            $user = $getUser($item->assigned_to);
-                            $recipients[] = $user->email;
+                        if( count( $item->assigned_to ) > 0) {
+
+                            foreach( $item->assigned_to as $key => $assignee ) {
+
+                                $user = $getUser( $assignee );
+
+                                if( !empty( $user ) ) {
+                                    $recipients[] = $user->email;
+                                }
+                            }
                         }
 
                         if ($item->created_by > 0) {


### PR DESCRIPTION
So, when dealing with assigned_to, array is the right data type instead of an int.

<!--
  Filling out this template is required when contributing.
  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->

### Description
<!-- We must be able to understand the design of your change from this description. -->
assigned_to is now an array instead of an int.

### Benefits
<!-- What benefits will be realized the code changes? -->
Users assigned to milestones, tasks, and bugs will receive comment notifications.

### Possible drawbacks
<!-- What are the possible side-effects or negative impacts of the code changes? -->
None.

### Applicable issues
<!-- Link any applicable Issues here -->
None.