### PR TITLE
assigned_to contains an array instead of an int.

### DIFF
--- a/src/includes/up-permissions-functions.php
+++ b/src/includes/up-permissions-functions.php
@@ -75,9 +75,9 @@ function upstream_permissions( $capability = null, $item_id = null ) {
     // used for the 'Actions' column to allow editing/deleting buttons
     if( isset( $item_id ) ) {
         $item = upstream_project_item_by_id( upstream_post_id(), $item_id );
-        $assigned_to  = isset( $item['assigned_to'] ) ? $item['assigned_to'] : null;
+        $assigned_to  = isset( $item['assigned_to'] ) ? ( array )$item['assigned_to'] : array();
         $created_by   = isset( $item['created_by'] ) ? $item['created_by'] : null;
-        if( $assigned_to == $current_user || $created_by == $current_user )
+        if( in_array( $current_user, $assigned_to ) || $created_by == $current_user )
             $return = true;
     }
 


### PR DESCRIPTION
<!--
  Filling out this template is required when contributing.
  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->

### Description
<!-- We must be able to understand the design of your change from this description. -->
assigned_to was treated as if it contains an int.

### Benefits
<!-- What benefits will be realized the code changes? -->
Return the correct user permissions.

### Possible drawbacks
<!-- What are the possible side-effects or negative impacts of the code changes? -->
None.

### Applicable issues
<!-- Link any applicable Issues here -->
UpStream Frontend Edit bugs number 94 and 95
