### PR TITLE
Implement export-as attribute to fix columns with multiple data

### DIFF
--- a/templates/archive-project.php
+++ b/templates/archive-project.php
@@ -347,6 +347,11 @@ if ( ! empty($ordering)) {
                                                 $columnsSchema); ?>
                                         </div>
                                     </form>
+                                    <?php
+                                    $exportTitleLabel     = __('Project Title', 'upstream');
+                                    $exportStartDateLabel = __('Start Date', 'upstream');
+                                    $exportEndDateLabel   = __('End Date', 'upstream');
+                                    ?>
                                     <table id="projects"
                                            class="o-data-table table table-bordered table-responsive table-hover is-orderable"
                                            cellspacing="0"
@@ -356,7 +361,12 @@ if ( ! empty($ordering)) {
                                            data-order-dir="<?php echo esc_attr($orderDir); ?>">
                                         <thead>
                                         <tr>
-                                            <th class="is-clickable is-orderable" data-column="title" role="button">
+                                            <th class="is-clickable is-orderable" data-column="title" role="button"
+                                                data-export-as="<?php echo implode(',', [
+                                                    $exportTitleLabel,
+                                                    $exportStartDateLabel,
+                                                    $exportEndDateLabel,
+                                                ]); ?>">
                                                 <?php echo esc_html($i18n['LB_PROJECT']); ?>
                                                 <span class="pull-right o-order-direction">
                           <i class="fa fa-sort"></i>
@@ -408,14 +418,23 @@ if ( ! empty($ordering)) {
                                             <tr class="t-row-<?php echo $isProjectIndexOdd ? 'odd' : 'even'; ?>"
                                                 data-id="<?php echo $project->id; ?>">
                                                 <td data-column="title"
-                                                    data-value="<?php echo esc_attr($project->title); ?>">
+                                                    data-value="<?php echo esc_attr($project->title); ?>"
+                                                    data-export-as="<?php echo implode(',', [
+                                                        $exportTitleLabel,
+                                                        $exportStartDateLabel,
+                                                        $exportEndDateLabel,
+                                                    ]); ?>">
                                                     <?php do_action('upstream:frontend.project.details.before_title',
                                                         $project); ?>
                                                     <a href="<?php echo $project->permalink; ?>">
-                                                        <?php echo esc_html($project->title); ?>
+                                                        <span data-export-as="<?php echo $exportTitleLabel; ?>"><?php echo esc_html($project->title); ?></span>
                                                     </a>
                                                     <br/>
-                                                    <small><?php echo $project->timeframe; ?></small>
+                                                    <small>
+                                                        <span data-export-as="<?php echo $exportStartDateLabel; ?>"><?php echo $project->startDate; ?></span>
+                                                        -
+                                                        <span data-export-as="<?php echo $exportEndDateLabel; ?>"><?php echo $project->endDate; ?></span>
+                                                    </small>
                                                 </td>
                                                 <?php if ($areClientsEnabled): ?>
                                                     <td data-column="client"

--- a/templates/assets/js/upstream.js
+++ b/templates/assets/js/upstream.js
@@ -779,6 +779,48 @@ jQuery(document).ready(function ($) {
                 $(this).prepend($('<td>' + visibleIndex + '</td>'));
             });
 
+            // Split the content of specific cells to multiple columns, id required.
+            $(clonedTable.find('th[data-export-as]')).each(function (thIndex, th) {
+                var $th = $(th);
+
+                var labels = $th.data('export-as').split(',');
+
+                // Split it into TH elements.
+                var $currentTh = $th;
+                $(labels).each(function (labelIndex, label) {
+                    // Replace the first TH with the first label.
+                    if (0 === labelIndex) {
+                        $currentTh.text(label);
+                    } else {
+                        // Append a new TH after the current one.
+                        var $newTh = $('<th>').text(label);
+                        $currentTh.after($newTh);
+                        $currentTh = $newTh;
+                    }
+                });
+
+                // Get the columns' data and split them as specified by export-as.
+                $(clonedTable.find('td[data-export-as]')).each(function (tdIndex, td) {
+                    var $td = $(td);
+
+                    // Split it into TD elements.
+                    var $currentTd = $td;
+                    var data = $td.find('[data-export-as]');
+
+                    $(labels).each(function (labelIndex, label) {
+                        // Replace the first TD with the first label.
+                        if (0 === labelIndex) {
+                            $currentTd.text($(data[0]).text());
+                        } else {
+                            // Append a new TH after the current one.
+                            var $newTd = $('<td>').text($(data[labelIndex]).text());
+                            $currentTd.after($newTd);
+                            $currentTd = $newTd;
+                        }
+                    });
+                });
+            });
+
             return clonedTable;
         }
 


### PR DESCRIPTION
This is a proposal for fixing the issue #787.

Implements a dynamic way to split columns' data when exporting. Only make sure to specify the `data-export-as` attribute to the TH, TD and SPAN elements. Each data fragment should be inside a container tag with the specific `data-export-as` attribute.