### PR TITLE
Fix for frontend edit. Create a lock when a user is editing a task or…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,31 @@
-.svn
-.git
-.DS_Store
-wpcom-helper.php
-
-/local.sh
 node_modules
 
-/.properties.ini
+# General exclusion of system files #
+#####################################
+.*
+*~
+!.gitignore
+!.htaccess
+!.editorconfig
+!.github
 
-/packages
+# Windows Files #
+#################
+Thumbs.db
+ehthumbs.db
+
+# Folder config file #
+######################
+Desktop.ini
+
+# Recycle Bin used on file shares #
+###################################
+$RECYCLE.BIN/
+
+# Misc files #
+##############
+config.codekit
+/package-lock.json
+
 /vendor
-.idea
 /dist

--- a/includes/class-up-project.php
+++ b/includes/class-up-project.php
@@ -1,4 +1,7 @@
 <?php
+//This include shouldn't be necessary however the wp_check_post_lock call fails
+//which is odd
+include_once 'wp-admin/includes/post.php';
 
 // Exit if accessed directly
 if ( ! defined('ABSPATH')) {
@@ -466,6 +469,15 @@ class UpStream_Project
     {
         $tasks      = $this->get_meta('tasks');
         $milestones = \UpStream\Milestones::getInstance()->getMilestonesFromProject($this->ID);
+
+        $wp_lock_check = wp_check_post_lock($this->ID);
+
+        if ($wp_lock_check) {
+            $user_info = get_userdata($wp_lock_check);
+            throw new \Exception(__("This project is being edited by " . $user_info->user_login . ". The other user must save their work.", 'upstream'));
+        } else {
+            delete_post_meta($this->ID , '_edit_lock');
+        }
 
         $i      = 0;
         $totals = [];

--- a/includes/class-up-project.php
+++ b/includes/class-up-project.php
@@ -1,7 +1,7 @@
 <?php
 //This include shouldn't be necessary however the wp_check_post_lock call fails
-//which is odd
-include_once 'wp-admin/includes/post.php';
+//in the frontend edit module which is odd
+@include_once 'wp-admin/includes/post.php';
 
 // Exit if accessed directly
 if ( ! defined('ABSPATH')) {


### PR DESCRIPTION
… milestone so another user cannot overwrite changes.


## Description

When a user is on the frontend edit screen and saves, this change removes the lock. The saving of "items" is not done the same as a project on the frontend edit screen it is done in the core plugin. I would have preferred to put this in the frontend edit area but cannot due to the backend design.

